### PR TITLE
Run the tests job on the large runner

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -39,7 +39,9 @@ jobs:
           fi
 
   tests:
-    runs-on: ubuntu-24.04
+    # pytest builds the Lean sandbox image from the Dockerfile; a stock
+    # runner's ~14GB disk cannot hold that build.
+    runs-on: epoch-research-x64-64core-256GB-2040GB
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The `Checks` / `tests` job has never passed on any branch (14/14 failures). Every run dies mid-`pytest` with `System.IO.IOException: No space left on device`, crashing the runner worker itself — which is why no pytest logs were ever uploaded.

The cause: the Docker integration tests (`tests/lean_sandbox.py`) deliberately build the Lean sandbox image from the Dockerfile via a compose `build:` section, and the Lean + Mathlib build does not fit on a stock `ubuntu-24.04` runner's ~14GB of free disk. This is the same reason the image build workflow already runs on the large runner (091941a).

This moves the `tests` job to the same runner class, `epoch-research-x64-64core-256GB-2040GB`. `check-version` stays on the stock runner.