### PR TITLE
Split the gold-proof sweep into its own CI job

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -38,9 +38,11 @@ jobs:
             exit 1
           fi
 
+  # The gold-proof sweep (~35 sequential SafeVerify checks, ~2h) dwarfs the
+  # rest of the suite (~15 min), so it runs as its own job for early signal.
+  # Both jobs build the Lean sandbox image from the Dockerfile in-test; a
+  # stock runner's ~14GB disk cannot hold that build.
   tests:
-    # pytest builds the Lean sandbox image from the Dockerfile; a stock
-    # runner's ~14GB disk cannot hold that build.
     runs-on: epoch-research-x64-64core-256GB-2040GB
     steps:
       - uses: actions/checkout@v4
@@ -60,4 +62,26 @@ jobs:
         run: uv sync
 
       - name: Run tests
-        run: uv run pytest
+        run: uv run pytest --ignore=tests/test_gold_proofs.py
+
+  gold-proofs:
+    runs-on: epoch-research-x64-64core-256GB-2040GB
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: pyproject.toml
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run the gold-proof sweep
+        run: uv run pytest tests/test_gold_proofs.py


### PR DESCRIPTION
This splits `Checks` into:

- **`tests`** — everything except `tests/test_gold_proofs.py` (124 tests): should report in ~15 min
- **`gold-proofs`** — the sweep alone (39 cases)

The two selections partition the suite exactly (124 + 39 = 163 collected).