### PR TITLE
Fix apn_erdos calling lean_prover with the pre-refactor signature

### DIFF
--- a/apn/task.py
+++ b/apn/task.py
@@ -147,7 +147,7 @@ def apn_erdos(
     return Task(
         dataset=erdos_dataset(names=name_list),
         solver=lean_prover(
-            max_attempts=99_999_999 if gated else 1,
+            gated=gated,
             literature=literature,
             agent_type=agent_type,
         ),


### PR DESCRIPTION
#9 changed `lean_prover(max_attempts: int, ...)` to `lean_prover(gated: bool, ...)` while #7 added `apn_erdos` against the old signature; the two merged independently without a textual conflict, so `main` currently raises `TypeError: lean_prover() got an unexpected keyword argument 'max_attempts'` as soon as the `apn_erdos` task is constructed. This switches the call to `gated=gated`, matching `apn_oeis` and `apn_fc100open`.

All three tasks construct cleanly with this change (350/492/86 samples).