### PR TITLE
Run the checks workflow on merge_group events

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,6 +2,7 @@ name: Checks
 
 on:
   pull_request:
+  merge_group:
   push:
     branches:
       - main
@@ -65,6 +66,10 @@ jobs:
         run: uv run pytest --ignore=tests/test_gold_proofs.py
 
   gold-proofs:
+    # Not a merge-queue-required check: at ~2h on a single runner it would
+    # serialize every merge, so queue runs skip it (it still runs on PRs and
+    # on every push to main).
+    if: github.event_name != 'merge_group'
     runs-on: epoch-research-x64-64core-256GB-2040GB
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Prerequisite for enabling the merge queue on `main`: queue runs are triggered by the `merge_group` event, which the checks workflow didn't listen for, so required checks would never report on queue branches and every queued PR would time out.

The gold-proof sweep is skipped on queue runs — at ~2h it isn't a required check and would serialize every merge. It still runs on PRs and on every push to main.