### PR TITLE
Collect per-test durations in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -62,7 +62,7 @@ jobs:
         run: uv sync
 
       - name: Run tests
-        run: uv run pytest --ignore=tests/test_gold_proofs.py
+        run: uv run pytest --ignore=tests/test_gold_proofs.py --durations=0
 
   gold-proofs:
     runs-on: epoch-research-x64-64core-256GB-2040GB
@@ -84,4 +84,4 @@ jobs:
         run: uv sync
 
       - name: Run the gold-proof sweep
-        run: uv run pytest tests/test_gold_proofs.py
+        run: uv run pytest tests/test_gold_proofs.py --durations=0


### PR DESCRIPTION
Adds `--durations=0` to both pytest invocations in `Checks`, so each job's log ends with the full per-test timing table (setup/call/teardown per test).

This gives real data for the remaining CI-speed decisions — how the gold-proof sweep's ~1h46m distributes across the 35 proofs (whether a few dominate or it's uniform, which determines how much 6–8-wide parallelization buys), and how much of the `tests` job is sandbox/image setup versus actual tests (the cold-cache tax).

Draft: opened to trigger a data-collection run; whether to keep the flag permanently is a follow-up call.