### PR TITLE
Split the isolation suites into their own CI job

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -60,10 +60,11 @@ jobs:
       - name: Run mypy
         run: uv run mypy
 
-  # The gold-proof sweep (~35 sequential SafeVerify checks, ~2h) dwarfs the
-  # rest of the suite (~15 min), so it runs as its own job for early signal.
-  # Both jobs build the Lean sandbox image from the Dockerfile in-test; a
-  # stock runner's ~14GB disk cannot hold that build.
+  # The gold-proof sweep (~2h of sequential SafeVerify checks) and the
+  # isolation suites (~55m compiling every committed spec in-container) each
+  # dwarf the rest of the suite (~7m), so they run as their own jobs for
+  # early signal. All three jobs build the Lean sandbox image from the
+  # Dockerfile in-test; a stock runner's ~14GB disk cannot hold that build.
   tests:
     runs-on: epoch-research-x64-64core-256GB-2040GB
     steps:
@@ -84,7 +85,38 @@ jobs:
         run: uv sync
 
       - name: Run tests
-        run: uv run pytest --ignore=tests/test_gold_proofs.py
+        run: >-
+          uv run pytest
+          --ignore=tests/test_gold_proofs.py
+          --ignore=tests/test_oeis_isolation.py
+          --ignore=tests/test_erdos_isolation.py
+          --ignore=tests/test_fc100_isolation.py
+
+  isolation:
+    runs-on: epoch-research-x64-64core-256GB-2040GB
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: pyproject.toml
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run the isolation suites
+        run: >-
+          uv run pytest
+          tests/test_oeis_isolation.py
+          tests/test_erdos_isolation.py
+          tests/test_fc100_isolation.py
 
   gold-proofs:
     runs-on: epoch-research-x64-64core-256GB-2040GB


### PR DESCRIPTION
Follow-up to the gold-proofs split, using the duration data from #14: the three isolation suites' module fixtures (which compile every committed isolated spec in the container) account for ~55 min of the ~62 min `tests` job — oeis 1543s, erdos 1475s (new since apn_erdos), fc100 255s — while everything else finishes in ~7 min combined.

`Checks` now runs three pytest jobs, all on the large runner (each still builds the Lean image in-test):

- **`tests`** — everything except gold proofs and isolation suites (132 tests): ~7 min of test time, the early-signal job.
- **`isolation`** — `test_oeis_isolation.py`, `test_erdos_isolation.py`, `test_fc100_isolation.py` (9 tests, ~55 min of spec compiles).
- **`gold-proofs`** — unchanged (39 cases, ~2h).

The three selections partition the suite exactly (132 + 9 + 39 = 180 collected).