### PR TITLE
Pin elan to a tagged release and bump to 0.1.5

### DIFF
--- a/apn/__init__.py
+++ b/apn/__init__.py
@@ -1,4 +1,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.4rc7"
+__version__ = "0.1.5"

--- a/apn/lean/Dockerfile
+++ b/apn/lean/Dockerfile
@@ -35,9 +35,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 ARG LEAN_VERSION=v4.27.0
-RUN curl -sSfL https://elan.lean-lang.org/elan-init.sh -o elan-init.sh \
-    && sh elan-init.sh -y --default-toolchain "leanprover/lean4:${LEAN_VERSION}" \
-    && rm elan-init.sh
+ARG ELAN_VERSION=v4.2.3
+RUN curl -sSfL "https://github.com/leanprover/elan/releases/download/${ELAN_VERSION}/elan-$(uname -m)-unknown-linux-gnu.tar.gz" \
+        | tar xz -C /tmp \
+    && /tmp/elan-init -y --default-toolchain "leanprover/lean4:${LEAN_VERSION}" \
+    && rm /tmp/elan-init
 
 ARG FC_BRANCH=auto_oeis
 ARG FC_COMMIT=67338a157bbb8d87e9a349d662f82a868bda6327

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apn"
-version = "0.1.4rc7"
+version = "0.1.5"
 description = "An Inspect implementation of the AlphaProof Nexus formal proof-search framework"
 requires-python = ">=3.13,<3.14"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "apn"
-version = "0.1.4rc7"
+version = "0.1.5"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
- Install elan from its pinned v4.2.3 release tarball instead. This is exactly the download the script performs as its last step, minus the platform detection — `$(uname -m)` covers that (x86_64 CI runner and arm64 local builds), and the tarball's `elan-init` binary takes the same flags the script forwarded.
- Bump `0.1.4rc7` → `0.1.5`

The Debian base stays on `debian:bookworm-slim`, which already tracks a fixed release.