### PR TITLE
Add systematic result metadata summarization

### DIFF
--- a/scripts/populate_results_repo.py
+++ b/scripts/populate_results_repo.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Populate LeanOpenProblems-results from selected plaintext runs.
+"""Populate LeanOpenProblems-results from metadata and selected plaintext runs.
 
 The export is additive: destination-only files are retained. Agent transcripts
 and operating-system metadata are omitted.
@@ -151,8 +151,8 @@ def plaintext_directory(logs_dir: Path, run: str) -> Path:
     return matches[0]
 
 
-def stage_run(destination: Path, target: Path) -> None:
-    """Stage an exported run without touching unrelated destination files."""
+def stage_path(destination: Path, target: Path) -> None:
+    """Stage one exported subtree without touching unrelated destination files."""
     relative_target = target.relative_to(destination)
     subprocess.run(
         ["git", "-C", str(destination), "add", "--", str(relative_target)],
@@ -182,6 +182,12 @@ def parse_args() -> argparse.Namespace:
         help="source logs directory (default: <repository>/logs)",
     )
     parser.add_argument(
+        "--metadata-dir",
+        type=Path,
+        default=repo_root / "metadata",
+        help="source metadata directory (default: <repository>/metadata)",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="compare source and destination without writing files",
@@ -191,12 +197,28 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> int:
     args = parse_args()
+    metadata_source = args.metadata_dir
+    if not metadata_source.is_dir():
+        raise RuntimeError(f"metadata directory does not exist: {metadata_source}")
+    metadata_target = args.dest / "metadata"
+    metadata_stats = sync_tree(
+        metadata_source, metadata_target, dry_run=args.dry_run
+    )
+    if not args.dry_run:
+        stage_path(args.dest, metadata_target)
+    metadata_prefix = "would change" if args.dry_run else "changed"
+    print(
+        f"metadata: {metadata_stats.files} files, "
+        f"{metadata_stats.symlinks} symlinks, "
+        f"{metadata_prefix} {metadata_stats.changes}"
+    )
+
     for run in args.runs:
         source = plaintext_directory(args.logs_dir, run)
         target = args.dest / "runs" / run
         stats = sync_tree(source, target, dry_run=args.dry_run)
         if not args.dry_run:
-            stage_run(args.dest, target)
+            stage_path(args.dest, target)
         prefix = "would change" if args.dry_run else "changed"
         print(
             f"{run}: {stats.files} files, {stats.symlinks} symlinks, "

--- a/scripts/summarize/collect.py
+++ b/scripts/summarize/collect.py
@@ -1,0 +1,198 @@
+"""Materialize normalized metadata from summarize eval logs.
+
+Examples::
+
+    python scripts/summarize/collect.py sequences \
+        --subset lite --eval logs/summarize/<sequences>.eval
+    python scripts/summarize/collect.py conjectures \
+        --subset lite --eval logs/summarize/<conjectures>.eval
+    python scripts/summarize/collect.py proofs \
+        --run-dir logs/<run> --eval logs/summarize/<proofs>.eval
+
+Later ``--eval`` arguments replace earlier submissions for the same id, making
+small patch-up runs deterministic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from inspect_ai.log import EvalSample, read_eval_log
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.summarize.task import (  # noqa: E402
+    load_provenance,
+    load_records,
+    plaintext_dir,
+    solved_samples,
+    subset_conjectures,
+)
+
+
+@dataclass(frozen=True)
+class Generated:
+    row: dict[str, Any]
+    metadata: dict[str, Any]
+    generation: dict[str, str]
+
+
+def _submitted_row(sample: EvalSample, tool_name: str) -> dict[str, Any] | None:
+    if sample.output and sample.output.completion:
+        try:
+            row = json.loads(sample.output.completion)
+            if isinstance(row, dict):
+                return row
+        except json.JSONDecodeError:
+            pass
+    for message in reversed(sample.messages or []):
+        for call in getattr(message, "tool_calls", None) or []:
+            if call.function == tool_name:
+                return dict(call.arguments)
+    return None
+
+
+def extract(log_paths: list[Path], tool_name: str) -> dict[str, Generated]:
+    """Extract submissions, with later log arguments winning by sample id."""
+    generated: dict[str, Generated] = {}
+    seen: set[str] = set()
+    for path in log_paths:
+        log = read_eval_log(str(path))
+        model = str(log.eval.model)
+        for sample in log.samples or []:
+            sample_id = str(sample.id)
+            seen.add(sample_id)
+            row = _submitted_row(sample, tool_name)
+            if row is None:
+                continue
+            generated[sample_id] = Generated(
+                row=row,
+                metadata=sample.metadata or {},
+                generation={"model": model, "source_eval": path.name},
+            )
+    missing = sorted(seen - generated.keys())
+    if missing:
+        print(f"warning: no {tool_name} submission for: {missing}", file=sys.stderr)
+    return generated
+
+
+def _output_path(path: Path) -> Path:
+    return path if path.is_absolute() else REPO_ROOT / path
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(value, ensure_ascii=False, indent=2) + "\n")
+    temporary.replace(path)
+    print(f"wrote {len(value)} entries to {path}")
+
+
+def collect_sequences(args: argparse.Namespace) -> int:
+    generated = extract(args.eval, "submit_sequence")
+    records = load_records()
+    oeis_ids = sorted(
+        {item.oeis_id for item in subset_conjectures(args.subset) if item.oeis_id},
+        key=lambda value: int(value[1:]),
+    )
+    output = {}
+    for oeis_id in oeis_ids:
+        item = generated.get(oeis_id)
+        output[oeis_id] = {
+            "name": records.get(oeis_id, {}).get("name"),
+            "description": item.row.get("description") if item else None,
+            "generation": item.generation if item else None,
+        }
+    write_json(_output_path(args.metadata_dir) / "sequences.json", output)
+    return 0
+
+
+def collect_conjectures(args: argparse.Namespace) -> int:
+    generated = extract(args.eval, "submit_conjecture")
+    provenance = load_provenance()
+    output = {}
+    for conjecture in subset_conjectures(args.subset):
+        item = generated.get(conjecture.id)
+        source = provenance.get(conjecture.id, {})
+        output[conjecture.id] = {
+            "oeis_id": conjecture.oeis_id,
+            "conjecture": item.row.get("conjecture") if item else None,
+            "proposer": source.get("proposer"),
+            "proposed_date": source.get("proposed_date"),
+            "generation": item.generation if item else None,
+        }
+    write_json(_output_path(args.metadata_dir) / "conjectures.json", output)
+    return 0
+
+
+def collect_proofs(args: argparse.Namespace) -> int:
+    generated = extract(args.eval, "submit_proof_summary")
+    run_dir = _output_path(args.run_dir)
+    allowed = {conjecture.id for conjecture in subset_conjectures(args.subset)}
+    solves = {
+        solve.id: solve
+        for solve in solved_samples(run_dir)
+        if solve.id in allowed
+    }
+
+    unexpected = sorted(generated.keys() - solves.keys())
+    if unexpected:
+        print(
+            f"warning: proof summaries do not match accepted samples in {run_dir}: "
+            f"{unexpected}",
+            file=sys.stderr,
+        )
+
+    written = 0
+    for sample_id, solve in sorted(solves.items()):
+        item = generated.get(sample_id)
+        value = {
+            "settlement": solve.settlement,
+            "proof_summary": item.row.get("proof_summary") if item else None,
+            "generation": item.generation if item else None,
+        }
+        write_json(solve.directory / "metadata.json", value)
+        written += 1
+    print(f"wrote proof metadata for {written} accepted samples under {plaintext_dir(run_dir)}")
+    return 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    for name, help_text in (
+        ("sequences", "write metadata/sequences.json"),
+        ("conjectures", "write metadata/conjectures.json"),
+    ):
+        command = subparsers.add_parser(name, help=help_text)
+        command.add_argument("--subset", default="lite")
+        command.add_argument("--eval", nargs="+", required=True, type=Path)
+        command.add_argument("--metadata-dir", type=Path, default=Path("metadata"))
+
+    proofs = subparsers.add_parser(
+        "proofs", help="write metadata.json beside each accepted proof"
+    )
+    proofs.add_argument("--run-dir", required=True, type=Path)
+    proofs.add_argument("--subset", default="lite")
+    proofs.add_argument("--eval", nargs="+", required=True, type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.command == "sequences":
+        return collect_sequences(args)
+    if args.command == "conjectures":
+        return collect_conjectures(args)
+    return collect_proofs(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/summarize/task.py
+++ b/scripts/summarize/task.py
@@ -1,0 +1,488 @@
+"""Inspect tasks for generating normalized OEIS metadata.
+
+The sequence and conjecture tasks are run once for the Lite dataset. Proof
+summaries are run once per accepted proof in an evaluation run. Deterministic
+collection into ``metadata/*.json`` and per-sample ``metadata.json`` files is
+handled by ``collect.py``.
+
+Examples::
+
+    inspect eval scripts/summarize/task.py@summarize_sequences \
+        -T subset=lite --model openai/gpt-5.6-sol --log-dir logs/summarize
+    inspect eval scripts/summarize/task.py@summarize_conjectures \
+        -T subset=lite -T metadata_dir=metadata \
+        --model openai/gpt-5.6-sol --log-dir logs/summarize
+    inspect eval scripts/summarize/task.py@summarize_proofs \
+        -T run_dir=logs/<run> -T subset=lite -T metadata_dir=metadata \
+        --model openai/gpt-5.6-sol --log-dir logs/summarize
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Literal, NamedTuple
+
+from inspect_ai import Task, task
+from inspect_ai.agent import AgentSubmit, as_solver, react
+from inspect_ai.dataset import MemoryDataset, Sample
+from inspect_ai.model import CompactionSummary
+from inspect_ai.solver import Generate, Solver, TaskState, solver
+from inspect_ai.tool import Tool, ToolResult, text_editor, tool
+from inspect_ai.util import sandbox, store
+
+import apn
+from apn.dataset import OEIS_DIR, fc_commit, load_subset, oeis_dataset
+from apn.layout import ENTRY_PATH
+from apn.task import COMPOSE_FILES_DIR, IMAGE_REPOSITORY, get_identifier_for_image
+from apn.tools import bash
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+OEIS_DATA = Path(apn.__file__).parent / "data" / "oeis"
+OEIS_METADATA = OEIS_DATA / "metadata"
+RECORDS_PATH = OEIS_METADATA / "snapshots" / "oeis_records.jsonl"
+PROVENANCE_PATH = OEIS_METADATA / "derived" / "provenance.jsonl"
+MATHLIB_SOURCE = "/workspace/leanproject/.lake/packages/mathlib/"
+
+
+def get_agent_compose_file() -> Path:
+    """Return a network-isolated compose file for a locally built agent image."""
+    image_context = Path(apn.__file__).parent / "lean"
+    oeis_fc_commit = fc_commit(OEIS_DIR)
+    content = f"""
+services:
+  default:
+    image: {IMAGE_REPOSITORY}:{get_identifier_for_image("agent", oeis_fc_commit)}
+    build:
+      context: {image_context}
+      target: agent
+      args:
+        FC_COMMIT: {oeis_fc_commit}
+    init: true
+    entrypoint: tail -f /dev/null
+    mem_limit: 10g
+    network_mode: none
+"""
+    path = COMPOSE_FILES_DIR / "summarize" / "compose.yaml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not path.exists() or path.read_text() != content:
+        path.write_text(content)
+    return path
+
+
+def _resolve(path: str | Path) -> Path:
+    """Resolve task arguments relative to the repository root."""
+    value = Path(path)
+    return value if value.is_absolute() else REPO_ROOT / value
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _read_json_object(path: Path) -> dict[str, Any] | None:
+    try:
+        value = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"warning: cannot read {path}: {exc}", file=sys.stderr)
+        return None
+    if not isinstance(value, dict):
+        print(f"warning: expected a JSON object in {path}", file=sys.stderr)
+        return None
+    return value
+
+
+def load_records() -> dict[str, dict[str, Any]]:
+    return {row["oeis_id"]: row["record"] for row in _read_jsonl(RECORDS_PATH)}
+
+
+def load_provenance() -> dict[str, dict[str, Any]]:
+    return {row["theorem_name"]: row for row in _read_jsonl(PROVENANCE_PATH)}
+
+
+class Conjecture(NamedTuple):
+    id: str
+    oeis_id: str | None
+    sketch: str
+
+
+class Solve(NamedTuple):
+    id: str
+    oeis_id: str
+    proof: str
+    settlement: Literal["proved", "disproved"]
+    directory: Path
+
+
+def subset_conjectures(subset: str) -> list[Conjecture]:
+    """Return the subset's conjectures in its authoritative order."""
+    names = load_subset(OEIS_DIR, subset)
+    samples = {str(sample.id): sample for sample in oeis_dataset(names=names)}
+    conjectures: list[Conjecture] = []
+    for name in names:
+        sample = samples.get(name)
+        if sample is None:
+            print(f"warning: {name} is absent from the OEIS dataset", file=sys.stderr)
+            continue
+        metadata = sample.metadata or {}
+        oeis_id = metadata.get("oeis_id")
+        sketch = metadata.get("sketch")
+        conjectures.append(
+            Conjecture(
+                id=name,
+                oeis_id=str(oeis_id) if oeis_id else None,
+                sketch=str(sketch) if sketch else str(sample.input),
+            )
+        )
+    return conjectures
+
+
+def plaintext_dir(run_dir: Path) -> Path:
+    matches = sorted(path for path in run_dir.glob("*_plaintext") if path.is_dir())
+    if len(matches) != 1:
+        raise ValueError(
+            f"expected exactly one *_plaintext dir under {run_dir}, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def solved_samples(run_dir: Path) -> list[Solve]:
+    """Read accepted proofs, skipping incomplete or malformed sample data."""
+    solves: list[Solve] = []
+    for sample_dir in sorted(plaintext_dir(run_dir).iterdir()):
+        if not sample_dir.is_dir():
+            continue
+
+        scores = _read_json_object(sample_dir / "scores.json")
+        score = (scores or {}).get("proof_scorer")
+        if not isinstance(score, dict):
+            print(f"warning: no proof_scorer score for {sample_dir.name}", file=sys.stderr)
+            continue
+        if score.get("value") != "C":
+            continue
+
+        info = _read_json_object(sample_dir / "info.json")
+        oeis_id = (info or {}).get("oeis_id")
+        if not oeis_id:
+            print(f"warning: no oeis_id for accepted sample {sample_dir.name}", file=sys.stderr)
+            continue
+
+        proof_path = sample_dir / "Submission" / "Spec.lean"
+        try:
+            proof = proof_path.read_text()
+        except OSError as exc:
+            print(f"warning: cannot read accepted proof {proof_path}: {exc}", file=sys.stderr)
+            continue
+
+        solves.append(
+            Solve(
+                id=sample_dir.name,
+                oeis_id=str(oeis_id),
+                proof=proof,
+                settlement="disproved" if ".disproof" in proof else "proved",
+                directory=sample_dir,
+            )
+        )
+    return solves
+
+
+def _load_metadata(path: Path) -> dict[str, dict[str, Any]]:
+    value = _read_json_object(path)
+    if value is None:
+        return {}
+    return {key: item for key, item in value.items() if isinstance(item, dict)}
+
+
+def sequence_prompt(oeis_id: str, record: dict[str, Any]) -> str:
+    return f"""\
+Write a short description of the OEIS sequence {oeis_id} for a public data catalog.
+The full OEIS record is below.
+
+Call submit_sequence with a description of at most about 10 words. Describe the
+sequence itself, not a conjecture about it. Plain text with LaTeX math is allowed.
+
+<oeis_record>
+{json.dumps(record, indent=2)}
+</oeis_record>
+"""
+
+
+def conjecture_prompt(
+    conjecture: Conjecture,
+    record: dict[str, Any],
+    provenance: dict[str, Any] | None,
+    sequence_description: str | None,
+) -> str:
+    return f"""\
+Write one concise sentence stating the conjecture {conjecture.id} about OEIS
+sequence {conjecture.oeis_id}. This is canonical conjecture metadata, independent
+of whether any particular model solved it.
+
+The conjecture sentence will be displayed immediately after this separate
+sequence-description field:
+
+<sequence_description>
+{sequence_description or "(unavailable)"}
+</sequence_description>
+
+Do not repeat or paraphrase that sequence description, its defining formula, or
+its OEIS identifier. State only the conjectured property, using a(n) directly
+when the sequence description already defines it. For example, prefer "For every
+prime ..." over "For the sequence a(n)=..., every prime ...".
+
+Call submit_conjecture with the sentence. Plain text with LaTeX math is allowed.
+
+<lean_statement>
+{conjecture.sketch}
+</lean_statement>
+
+<oeis_record>
+{json.dumps(record, indent=2)}
+</oeis_record>
+
+<provenance>
+{json.dumps(provenance, indent=2)}
+</provenance>
+"""
+
+
+def proof_prompt(
+    solve: Solve,
+    record: dict[str, Any],
+    provenance: dict[str, Any] | None,
+    sequence_description: str | None,
+    conjecture_description: str | None,
+) -> str:
+    noun = "proof" if solve.settlement == "proved" else "disproof"
+    return f"""\
+An AI agent {solve.settlement} the conjecture {solve.id} about OEIS sequence
+{solve.oeis_id}. The accepted {noun} is in {ENTRY_PATH}.
+
+Call submit_proof_summary with one or two concise sentences explaining the key
+mathematical ideas of this specific {noun}. Do not restate the sequence or
+conjecture. Focus exclusively on the mathematical argument: omit Lean tactics,
+library lemmas, proof-assistant architecture, implementation details, and claims
+that a computation is "kernel-checked", "verified", or "certified" merely because
+it was formalized. Describe a finite or modular computation by its mathematical
+role instead.
+
+Examples of the intended style:
+- "a kernel-checked finite avoidance computation" becomes
+  "a finite avoidance computation";
+- "a verified bit-sieve" becomes "a bit-sieve";
+- "segmented, kernel-checked binary exponentiation" becomes
+  "segmented binary exponentiation";
+- "Kernel computation checks each candidate" becomes
+  "Direct computation checks each candidate";
+- "Kernel-checked modular computations establish ..." becomes
+  "Modular computations establish ...".
+
+Plain text with LaTeX math is allowed.
+
+Canonical sequence description:
+{sequence_description or "(unavailable)"}
+
+Canonical conjecture description:
+{conjecture_description or "(unavailable)"}
+
+A Lean 4 toolchain with the full Mathlib source tree ({MATHLIB_SOURCE}) is
+available, along with `rg` and `python`. Investigate the accepted {noun} as much
+as useful before summarizing its mathematical argument.
+
+<oeis_record>
+{json.dumps(record, indent=2)}
+</oeis_record>
+
+<provenance>
+{json.dumps(provenance, indent=2)}
+</provenance>
+"""
+
+
+@tool
+def submit_sequence() -> Tool:
+    async def execute(description: str) -> ToolResult:
+        """Submit a short description of the OEIS sequence.
+
+        Args:
+          description: Description of the sequence, at most about 10 words.
+        """
+        store().set("summary", {"description": description})
+        return "Submitted."
+
+    return execute
+
+
+@tool
+def submit_conjecture() -> Tool:
+    async def execute(conjecture: str) -> ToolResult:
+        """Submit a concise statement of the conjecture.
+
+        Args:
+          conjecture: One sentence stating the conjecture.
+        """
+        store().set("summary", {"conjecture": conjecture})
+        return "Submitted."
+
+    return execute
+
+
+@tool
+def submit_proof_summary() -> Tool:
+    async def execute(proof_summary: str) -> ToolResult:
+        """Submit a concise summary of the accepted proof or disproof.
+
+        Args:
+          proof_summary: One or two sentences naming the proof's key ideas.
+        """
+        store().set("summary", {"proof_summary": proof_summary})
+        return "Submitted."
+
+    return execute
+
+
+@solver
+def summarizer(kind: Literal["sequence", "conjecture", "proof"]) -> Solver:
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        if kind == "proof":
+            await sandbox().write_file(ENTRY_PATH, state.metadata["proof"])
+            tools = [text_editor(), bash(timeout=300)]
+            submit = AgentSubmit(
+                tool=submit_proof_summary(),
+                name="submit_proof_summary",
+                keep_in_messages=True,
+            )
+        elif kind == "conjecture":
+            tools = []
+            submit = AgentSubmit(
+                tool=submit_conjecture(),
+                name="submit_conjecture",
+                keep_in_messages=True,
+            )
+        else:
+            tools = []
+            submit = AgentSubmit(
+                tool=submit_sequence(),
+                name="submit_sequence",
+                keep_in_messages=True,
+            )
+
+        agent = react(
+            tools=tools,
+            submit=submit,
+            compaction=CompactionSummary(threshold=300_000),
+        )
+        state = await as_solver(agent)(state, generate)
+
+        summary = state.store.get("summary")
+        if summary is not None:
+            state.output.completion = json.dumps(summary)
+        state.completed = True
+        return state
+
+    return solve
+
+
+@task
+def summarize_sequences(subset: str = "lite", token_limit: int = 500_000) -> Task:
+    records = load_records()
+    oeis_ids = sorted(
+        {item.oeis_id for item in subset_conjectures(subset) if item.oeis_id},
+        key=lambda value: int(value[1:]),
+    )
+    samples = []
+    for oeis_id in oeis_ids:
+        record = records.get(oeis_id)
+        if record is None:
+            print(f"warning: no OEIS record for {oeis_id}", file=sys.stderr)
+            continue
+        samples.append(
+            Sample(
+                input=sequence_prompt(oeis_id, record),
+                id=oeis_id,
+                metadata={"oeis_id": oeis_id},
+            )
+        )
+    return Task(
+        dataset=MemoryDataset(samples),
+        solver=summarizer("sequence"),
+        token_limit=token_limit,
+    )
+
+
+@task
+def summarize_conjectures(
+    subset: str = "lite",
+    metadata_dir: str = "metadata",
+    token_limit: int = 500_000,
+) -> Task:
+    records = load_records()
+    provenance = load_provenance()
+    sequences = _load_metadata(_resolve(metadata_dir) / "sequences.json")
+    samples = []
+    for conjecture in subset_conjectures(subset):
+        record = records.get(conjecture.oeis_id or "", {})
+        sequence = sequences.get(conjecture.oeis_id or "") or {}
+        samples.append(
+            Sample(
+                input=conjecture_prompt(
+                    conjecture,
+                    record,
+                    provenance.get(conjecture.id),
+                    sequence.get("description"),
+                ),
+                id=conjecture.id,
+                metadata={"oeis_id": conjecture.oeis_id},
+            )
+        )
+    return Task(
+        dataset=MemoryDataset(samples),
+        solver=summarizer("conjecture"),
+        token_limit=token_limit,
+    )
+
+
+@task
+def summarize_proofs(
+    run_dir: str,
+    subset: str = "lite",
+    metadata_dir: str = "metadata",
+    token_limit: int = 500_000,
+) -> Task:
+    records = load_records()
+    provenance = load_provenance()
+    metadata_root = _resolve(metadata_dir)
+    sequences = _load_metadata(metadata_root / "sequences.json")
+    conjectures = _load_metadata(metadata_root / "conjectures.json")
+
+    allowed = {conjecture.id for conjecture in subset_conjectures(subset)}
+    samples = []
+    for solve in solved_samples(_resolve(run_dir)):
+        if solve.id not in allowed:
+            continue
+        sequence = sequences.get(solve.oeis_id) or {}
+        conjecture = conjectures.get(solve.id) or {}
+        samples.append(
+            Sample(
+                input=proof_prompt(
+                    solve,
+                    records.get(solve.oeis_id, {}),
+                    provenance.get(solve.id),
+                    sequence.get("description"),
+                    conjecture.get("conjecture"),
+                ),
+                id=solve.id,
+                metadata={
+                    "proof": solve.proof,
+                    "oeis_id": solve.oeis_id,
+                    "settlement": solve.settlement,
+                },
+            )
+        )
+    return Task(
+        dataset=MemoryDataset(samples),
+        solver=summarizer("proof"),
+        sandbox=("docker", str(get_agent_compose_file())),
+        token_limit=token_limit,
+    )

--- a/tests/test_summarize.py
+++ b/tests/test_summarize.py
@@ -1,0 +1,28 @@
+"""Fast checks for the metadata summarization tasks. No model or Docker calls."""
+
+from pathlib import Path
+
+from apn.dataset import OEIS_DIR, fc_commit
+from apn.task import get_identifier_for_image
+from scripts.summarize.task import (
+    get_agent_compose_file,
+    summarize_conjectures,
+    summarize_sequences,
+)
+
+
+def test_lite_catalog_tasks_load_current_dataset(tmp_path: Path) -> None:
+    sequences = summarize_sequences()
+    conjectures = summarize_conjectures(metadata_dir=str(tmp_path))
+
+    assert len(sequences.dataset) == 99  # two Lite conjectures share one sequence
+    assert len(conjectures.dataset) == 100
+
+
+def test_proof_summarizer_compose_uses_oeis_pin() -> None:
+    commit = fc_commit(OEIS_DIR)
+    compose = get_agent_compose_file().read_text()
+
+    assert get_identifier_for_image("agent", commit) in compose
+    assert f"FC_COMMIT: {commit}" in compose
+    assert "network_mode: none" in compose


### PR DESCRIPTION
## Summary

- add Inspect tasks for Lite sequence, conjecture, and accepted-proof summaries
- preserve the interactive, network-isolated Lean sandbox for proof summarization
- collect normalized root catalogs and per-sample metadata deterministically from eval logs
- export the root metadata directory alongside selected plaintext runs
- add fast regression coverage for current dataset loading and the pinned sandbox image

## Validation

- ruff check on all changed Python files
- strict mypy on all changed Python files
- 28 focused dataset, registry, pin, and summarization tests
- constructed 99 sequence, 100 conjecture, and 44 Fable proof samples
- regenerated Lite catalogs and 44 Fable metadata files in a temporary directory; outputs matched the existing generated files byte for byte
- exporter dry-run against the results repository reported no changes

## Scope

No generated metadata, logs, plaintext runs, or exported results are included in this PR.

## Compatibility fixes found while rebasing onto main

The original results-branch implementation referenced the pre-reorganization OEIS metadata paths and older load_subset and image-tag APIs. This branch uses the canonical metadata/snapshots and metadata/derived paths, passes OEIS_DIR to load_subset, and pins the sandbox image build to the OEIS Formal Conjectures commit.

A model-backed Inspect eval and Docker rebuild were not rerun for this PR; task construction and compose generation were verified without starting Docker.