### PR TITLE
Apply Bloom's statement-selection verdicts; add the bloom68 config

### DIFF
--- a/apn/data/erdos/ERDOS_PROBLEM_STATEMENT_SELECTION.md
+++ b/apn/data/erdos/ERDOS_PROBLEM_STATEMENT_SELECTION.md
@@ -19,14 +19,11 @@ Of the 48 modules, 15 hold a single research statement, 30 hold a default
 statement plus alternatives under `erdos_N.variants`, two (208 and 812) split
 the problem into statements under `erdos_N.parts`, and one (508, which
 predates the usual naming scheme) holds `HadwigerNelsonProblem` plus solved
-bounds. The variants mix stronger conjectures, weaker or solved bounds,
-special cases, and related questions, with no uniform implication ordering.
-This note records which statement represents each problem; the
+bounds. This note records which statement represents each problem; the
 machine-readable selection is `subsets/bloom_selection.json`.
 
 - The 15 single-statement modules: use the statement.
-- The 30 modules with variants: use the default (non-variant) statement, even
-  when a variant is the mathematically stronger claim.
+- The 30 modules with variants: use the default (non-variant) statement.
 - The two modules with parts use Thomas Bloom's explicit picks (2026-08-26):
   `erdos_208.parts.i` and `erdos_812.parts.i`.
 - Problem 508 (Hadwiger–Nelson): the module's one open statement,

--- a/apn/data/erdos/ERDOS_PROBLEM_STATEMENT_SELECTION.md
+++ b/apn/data/erdos/ERDOS_PROBLEM_STATEMENT_SELECTION.md
@@ -1,18 +1,32 @@
 # Erdős problem statement selection
 
-Thomas Bloom selected 70 Erdős problem numbers for this benchmark; 48 of them
-have formalized statements in FC (reviewed at FC commit
-`56534c04092446f2fd549d2865f2496924812da8`). Most of the 48 modules hold either
-a single statement or a default statement plus alternatives under
-`erdos_N.variants`; two split the problem into statements under
-`erdos_N.parts`. The variants mix stronger conjectures, weaker or solved
-bounds, special cases, and related questions, with no uniform implication
-ordering. This note records which statement represents each problem; the
+Thomas Bloom selected 70 Erdős problem numbers for this benchmark:
+
+> 1, 3, 5, 7, 20, 23, 28, 30, 39, 41, 52, 61, 66, 68, 74, 77, 86, 89, 97, 101,
+> 104, 107, 120, 126, 128, 138, 165, 172, 181, 184, 208, 213, 241, 242, 322,
+> 324, 364, 371, 376, 406, 431, 478, 500, 508, 548, 564, 571, 583, 595, 647,
+> 672, 713, 714, 723, 773, 812, 821, 829, 901, 952, 970, 972, 975, 1003, 1020,
+> 1057, 1083, 1159, 1206, 1207
+
+48 of them have formalized statements in FC (reviewed at FC commit
+`56534c04092446f2fd549d2865f2496924812da8`); those are this dataset. Of the
+other 22, 18 were formalized by our own autoformalization pipeline (the
+`erdos_autoformalized` dataset next door), and the remaining 4 -- 77, 165,
+500, 901, whose main questions are estimate-type ("determine the order of
+magnitude") -- are not in the benchmark.
+
+Of the 48 modules, 15 hold a single research statement, 30 hold a default
+statement plus alternatives under `erdos_N.variants`, two (208 and 812) split
+the problem into statements under `erdos_N.parts`, and one (508, which
+predates the usual naming scheme) holds `HadwigerNelsonProblem` plus solved
+bounds. The variants mix stronger conjectures, weaker or solved bounds,
+special cases, and related questions, with no uniform implication ordering.
+This note records which statement represents each problem; the
 machine-readable selection is `subsets/bloom_selection.json`.
 
-- Modules with a single statement: use it.
-- Modules with variants: use the default (non-variant) statement, even when a
-  variant is the mathematically stronger claim.
+- The 15 single-statement modules: use the statement.
+- The 30 modules with variants: use the default (non-variant) statement, even
+  when a variant is the mathematically stronger claim.
 - The two modules with parts use Thomas Bloom's explicit picks (2026-08-26):
   `erdos_208.parts.i` and `erdos_812.parts.i`.
 - Problem 508 (Hadwiger–Nelson): the module's one open statement,

--- a/apn/data/erdos/ERDOS_PROBLEM_STATEMENT_SELECTION.md
+++ b/apn/data/erdos/ERDOS_PROBLEM_STATEMENT_SELECTION.md
@@ -1,108 +1,26 @@
 # Erdős problem statement selection
 
-## Background
+Thomas Bloom selected 70 Erdős problem numbers for this benchmark; 48 of them
+have formalized statements in FC (reviewed at FC commit
+`56534c04092446f2fd549d2865f2496924812da8`). Most of the 48 modules hold either
+a single statement or a default statement plus alternatives under
+`erdos_N.variants`; two split the problem into statements under
+`erdos_N.parts`. The variants mix stronger conjectures, weaker or solved
+bounds, special cases, and related questions, with no uniform implication
+ordering. This note records which statement represents each problem; the
+machine-readable selection is `subsets/bloom_selection.json`.
 
-Thomas Bloom selected 70 Erdős problem numbers for this review. 48 of those problems have formalized statements in FC and 22 do not. Of the 48 formalized problems, 15 have one substantive research statement and 33 have more than one. This decision concerns statement selection in those 33 multi-statement modules.
+- Modules with a single statement: use it.
+- Modules with variants: use the default (non-variant) statement, even when a
+  variant is the mathematically stronger claim.
+- The two modules with parts use Thomas Bloom's explicit picks (2026-08-26):
+  `erdos_208.parts.i` and `erdos_812.parts.i`.
+- Problem 508 (Hadwiger–Nelson): the module's one open statement,
+  `HadwigerNelsonProblem`, is value-typed (`χ(ℝ²) = answer(sorry)`) and ships
+  as an excluded manifest row. In its place the selection carries three derived
+  prove-or-disprove samples, `χ(ℝ²) = 5`, `= 6`, and `= 7` (the value is known
+  to lie in {5, 6, 7}) -- see the Hadwiger–Nelson special case in
+  `scripts/erdos_isolation.py`.
 
-This review was performed against FC commit `56534c04092446f2fd549d2865f2496924812da8`.
-
-30 modules have a default theorem named `erdos_N` and place related results or alternative formulations under `erdos_N.variants`. Two modules instead split the source problem into statements under `erdos_N.parts`.
-
-The variants serve several purposes. They include stronger conjectures, weaker or solved bounds, special cases, generalisations, equivalent formulations, and related questions. Consequently, there is not always a single implication ordering among all statements in a module. A review of the 33 modules found a clear strongest or hardest endpoint in 23 cases, a natural but qualified candidate in five cases, and no unique candidate in five cases.
-
-## Decision
-
-Use the following rule when selecting one representative statement from each module:
-
-1. The selected declaration must have the `research open` category.
-2. If a module has a default statement and variants, use the default non-variant statement. This rule applies even when a variant is known or intended to be stronger.
-3. If the source problem is divided into parts, use the stronger part:
-   - For Problem 208, use `erdos_208.parts.ii`.
-   - For Problem 812, use `erdos_812.parts.i`.
-4. Problem 508 predates the usual naming scheme. Use `HadwigerNelsonProblem`, its main exact-value question.
-
-## Selected statements
-
-| Problem | Selected statement | Reason |
-|---:|---|---|
-| 1 | `erdos_1` | Default statement; variants present |
-| 3 | `erdos_3` | Single statement |
-| 5 | `erdos_5` | Default statement; variants present |
-| 7 | `erdos_7` | Single statement |
-| 20 | `erdos_20` | Default statement; variants present |
-| 23 | `erdos_23` | Default statement; variants present |
-| 28 | `erdos_28` | Single statement |
-| 30 | `erdos_30` | Single statement |
-| 39 | `erdos_39` | Single statement |
-| 41 | `erdos_41` | Default statement; variants present |
-| 52 | `erdos_52` | Single statement |
-| 61 | `erdos_61` | Default statement; variants present |
-| 66 | `erdos_66` | Single statement |
-| 68 | `erdos_68` | Single statement |
-| 74 | `erdos_74` | Default statement; variants present |
-| 89 | `erdos_89` | Default statement; variants present |
-| 97 | `erdos_97` | Default statement; variants present |
-| 101 | `erdos_101` | Single statement |
-| 107 | `erdos_107` | Default statement; variants present |
-| 120 | `erdos_120` | Default statement; variants present |
-| 126 | `erdos_126` | Default statement; variants present |
-| 128 | `erdos_128` | Single statement |
-| 138 | `erdos_138` | Default statement; variants present |
-| 172 | `erdos_172` | Single statement |
-| 184 | `erdos_184` | Default statement; variants present |
-| 208 | `erdos_208.parts.ii` | Stronger part |
-| 213 | `erdos_213` | Default statement; variants present |
-| 241 | `erdos_241` | Default statement; variants present |
-| 242 | `erdos_242` | Default statement; variants present |
-| 324 | `erdos_324` | Default statement; variants present |
-| 364 | `erdos_364` | Default statement; variants present |
-| 371 | `erdos_371` | Single statement |
-| 376 | `erdos_376` | Default statement; variants present |
-| 406 | `erdos_406` | Default statement; variants present |
-| 508 | `HadwigerNelsonProblem` | Main statement; nonstandard naming |
-| 564 | `erdos_564` | Single statement |
-| 595 | `erdos_595` | Default statement; variants present |
-| 647 | `erdos_647` | Default statement; variants present |
-| 672 | `erdos_672` | Default statement; variants present |
-| 723 | `erdos_723` | Default statement; variants present |
-| 812 | `erdos_812.parts.i` | Stronger part |
-| 821 | `erdos_821` | Default statement; variants present |
-| 829 | `erdos_829` | Default statement; variants present |
-| 952 | `erdos_952` | Single statement |
-| 972 | `erdos_972` | Single statement |
-| 975 | `erdos_975` | Default statement; variants present |
-| 1003 | `erdos_1003` | Default statement; variants present |
-| 1057 | `erdos_1057` | Default statement; variants present |
-
-## Open-category check
-
-All 48 selected Lean declarations have the `research open` category.
-
-## Why the selected parts are stronger
-
-The comparisons between the parts are mathematical relationships between their statements. They are not currently recorded as Lean implication theorems.
-
-For Problem 208, Part II conjectures the squarefree-number gap bound
-
-\[
-s_{n+1}-s_n \leq (1+o(1))\frac{\pi^2}{6}
-  \frac{\log s_n}{\log\log s_n}.
-\]
-
-This implies the logarithmic-order variant and hence the subpolynomial bound in Part I:
-
-\[
-\text{Part II} \Longrightarrow O(\log s_n) \Longrightarrow \text{Part I}.
-\]
-
-For Problem 812, Part I conjectures a fixed multiplicative gap between consecutive diagonal Ramsey numbers:
-
-\[
-R(n+1)/R(n) \geq 1+c
-\]
-
-eventually, for some `c > 0`. It gives `R(n+1) - R(n) >= c R(n)`. The standard exponential growth of `R(n)` then implies the quadratic additive-gap bound in Part II:
-
-\[
-\text{Part I} \Longrightarrow \text{Part II}.
-\]
+Every selected statement had the `research open` category at the pin
+(asserted by `tests/test_erdos.py`).

--- a/apn/data/erdos/Isolated/Erdos508.HadwigerNelsonProblem.eq5.lean
+++ b/apn/data/erdos/Isolated/Erdos508.HadwigerNelsonProblem.eq5.lean
@@ -1,0 +1,48 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Erdős Problem 508
+
+*Reference:* [erdosproblems.com/508](https://www.erdosproblems.com/508)
+
+proven by considering the [Moser-Spindel graph]
+or the [Golomb graph]
+*At least 4 colors are required:* [Moser-Spindel graph](https://de.wikipedia.org/wiki/Moser-Spindel)
+*At least 4 colors are required:* [Golomb graph](https://en.wikipedia.org/wiki/Golomb_graph)
+*At least 5 colors are required:* [de Grey 2018](https://arxiv.org/abs/1804.02385)
+-/
+
+open SimpleGraph
+open scoped EuclideanGeometry
+
+namespace Erdos508
+
+scoped notation "χ(ℝ²)" => SimpleGraph.chromaticNumber (UnitDistancePlaneGraph Set.univ)
+
+/--
+The Hadwiger–Nelson problem asks: How many colors are required to color the plane
+such that no two points at distance 1 from each other have the same color?
+-/
+theorem HadwigerNelsonProblem :
+    χ(ℝ²) = 5 := by
+  sorry
+
+end Erdos508
+
+theorem Erdos508.HadwigerNelsonProblem.disproof : ¬ (type_of% @Erdos508.HadwigerNelsonProblem) := sorry

--- a/apn/data/erdos/Isolated/Erdos508.HadwigerNelsonProblem.eq5.lean
+++ b/apn/data/erdos/Isolated/Erdos508.HadwigerNelsonProblem.eq5.lean
@@ -39,10 +39,10 @@ scoped notation "χ(ℝ²)" => SimpleGraph.chromaticNumber (UnitDistancePlaneGra
 The Hadwiger–Nelson problem asks: How many colors are required to color the plane
 such that no two points at distance 1 from each other have the same color?
 -/
-theorem HadwigerNelsonProblem :
+theorem HadwigerNelsonProblem.eq5 :
     χ(ℝ²) = 5 := by
   sorry
 
 end Erdos508
 
-theorem Erdos508.HadwigerNelsonProblem.disproof : ¬ (type_of% @Erdos508.HadwigerNelsonProblem) := sorry
+theorem Erdos508.HadwigerNelsonProblem.eq5.disproof : ¬ (type_of% @Erdos508.HadwigerNelsonProblem.eq5) := sorry

--- a/apn/data/erdos/Isolated/Erdos508.HadwigerNelsonProblem.eq6.lean
+++ b/apn/data/erdos/Isolated/Erdos508.HadwigerNelsonProblem.eq6.lean
@@ -39,10 +39,10 @@ scoped notation "χ(ℝ²)" => SimpleGraph.chromaticNumber (UnitDistancePlaneGra
 The Hadwiger–Nelson problem asks: How many colors are required to color the plane
 such that no two points at distance 1 from each other have the same color?
 -/
-theorem HadwigerNelsonProblem :
+theorem HadwigerNelsonProblem.eq6 :
     χ(ℝ²) = 6 := by
   sorry
 
 end Erdos508
 
-theorem Erdos508.HadwigerNelsonProblem.disproof : ¬ (type_of% @Erdos508.HadwigerNelsonProblem) := sorry
+theorem Erdos508.HadwigerNelsonProblem.eq6.disproof : ¬ (type_of% @Erdos508.HadwigerNelsonProblem.eq6) := sorry

--- a/apn/data/erdos/Isolated/Erdos508.HadwigerNelsonProblem.eq6.lean
+++ b/apn/data/erdos/Isolated/Erdos508.HadwigerNelsonProblem.eq6.lean
@@ -1,0 +1,48 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Erdős Problem 508
+
+*Reference:* [erdosproblems.com/508](https://www.erdosproblems.com/508)
+
+proven by considering the [Moser-Spindel graph]
+or the [Golomb graph]
+*At least 4 colors are required:* [Moser-Spindel graph](https://de.wikipedia.org/wiki/Moser-Spindel)
+*At least 4 colors are required:* [Golomb graph](https://en.wikipedia.org/wiki/Golomb_graph)
+*At least 5 colors are required:* [de Grey 2018](https://arxiv.org/abs/1804.02385)
+-/
+
+open SimpleGraph
+open scoped EuclideanGeometry
+
+namespace Erdos508
+
+scoped notation "χ(ℝ²)" => SimpleGraph.chromaticNumber (UnitDistancePlaneGraph Set.univ)
+
+/--
+The Hadwiger–Nelson problem asks: How many colors are required to color the plane
+such that no two points at distance 1 from each other have the same color?
+-/
+theorem HadwigerNelsonProblem :
+    χ(ℝ²) = 6 := by
+  sorry
+
+end Erdos508
+
+theorem Erdos508.HadwigerNelsonProblem.disproof : ¬ (type_of% @Erdos508.HadwigerNelsonProblem) := sorry

--- a/apn/data/erdos/Isolated/Erdos508.HadwigerNelsonProblem.eq7.lean
+++ b/apn/data/erdos/Isolated/Erdos508.HadwigerNelsonProblem.eq7.lean
@@ -39,10 +39,10 @@ scoped notation "χ(ℝ²)" => SimpleGraph.chromaticNumber (UnitDistancePlaneGra
 The Hadwiger–Nelson problem asks: How many colors are required to color the plane
 such that no two points at distance 1 from each other have the same color?
 -/
-theorem HadwigerNelsonProblem :
+theorem HadwigerNelsonProblem.eq7 :
     χ(ℝ²) = 7 := by
   sorry
 
 end Erdos508
 
-theorem Erdos508.HadwigerNelsonProblem.disproof : ¬ (type_of% @Erdos508.HadwigerNelsonProblem) := sorry
+theorem Erdos508.HadwigerNelsonProblem.eq7.disproof : ¬ (type_of% @Erdos508.HadwigerNelsonProblem.eq7) := sorry

--- a/apn/data/erdos/Isolated/Erdos508.HadwigerNelsonProblem.eq7.lean
+++ b/apn/data/erdos/Isolated/Erdos508.HadwigerNelsonProblem.eq7.lean
@@ -1,0 +1,48 @@
+/-
+Copyright 2025 The Formal Conjectures Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-/
+
+import FormalConjecturesUtil
+
+/-!
+# Erdős Problem 508
+
+*Reference:* [erdosproblems.com/508](https://www.erdosproblems.com/508)
+
+proven by considering the [Moser-Spindel graph]
+or the [Golomb graph]
+*At least 4 colors are required:* [Moser-Spindel graph](https://de.wikipedia.org/wiki/Moser-Spindel)
+*At least 4 colors are required:* [Golomb graph](https://en.wikipedia.org/wiki/Golomb_graph)
+*At least 5 colors are required:* [de Grey 2018](https://arxiv.org/abs/1804.02385)
+-/
+
+open SimpleGraph
+open scoped EuclideanGeometry
+
+namespace Erdos508
+
+scoped notation "χ(ℝ²)" => SimpleGraph.chromaticNumber (UnitDistancePlaneGraph Set.univ)
+
+/--
+The Hadwiger–Nelson problem asks: How many colors are required to color the plane
+such that no two points at distance 1 from each other have the same color?
+-/
+theorem HadwigerNelsonProblem :
+    χ(ℝ²) = 7 := by
+  sorry
+
+end Erdos508
+
+theorem Erdos508.HadwigerNelsonProblem.disproof : ¬ (type_of% @Erdos508.HadwigerNelsonProblem) := sorry

--- a/apn/data/erdos/NOTICE.md
+++ b/apn/data/erdos/NOTICE.md
@@ -6,4 +6,4 @@ The selection of 48 is based on Thomas Bloom's selection, see `ERDOS_PROBLEM_STA
 
 `samples.jsonl` lists every research-category statement in those files.
 
-`subsets/bloom_selection.json` lists the 50 selected statements (one per problem, except 508, which contributes three derived prove-or-disprove samples).
+`subsets/bloom_selection.json` lists the 50 selected statements.

--- a/apn/data/erdos/NOTICE.md
+++ b/apn/data/erdos/NOTICE.md
@@ -6,4 +6,4 @@ The selection of 48 is based on Thomas Bloom's selection, see `ERDOS_PROBLEM_STA
 
 `samples.jsonl` lists every research-category statement in those files.
 
-`subsets/bloom_selection.json` lists the 47 selected statements.
+`subsets/bloom_selection.json` lists the 50 selected statements (one per problem, except 508, which contributes three derived prove-or-disprove samples).

--- a/apn/data/erdos/samples.jsonl
+++ b/apn/data/erdos/samples.jsonl
@@ -89,6 +89,9 @@
 {"id": "Erdos508.HadwigerNelsonAtLeast4", "source": "Sources/508.lean", "erdos_number": 508, "category_at_pin": "research solved", "answer_form": null}
 {"id": "Erdos508.HadwigerNelsonAtLeastFive", "source": "Sources/508.lean", "erdos_number": 508, "category_at_pin": "research solved", "answer_form": null}
 {"id": "Erdos508.HadwigerNelsonProblem", "source": "Sources/508.lean", "excluded": "value-typed answer(sorry): the placeholder elaborates to a position-labeled sorryAx in the statement's type, so the statement cannot be closed (or even stated) without the paper's google.answer \"with_auxiliary\" machinery, and SafeVerify cannot score it", "erdos_number": 508, "category_at_pin": "research open"}
+{"id": "Erdos508.HadwigerNelsonProblem.eq5", "source": "Sources/508.lean", "erdos_number": 508, "category_at_pin": "research open", "answer_form": null, "decl_name": "Erdos508.HadwigerNelsonProblem"}
+{"id": "Erdos508.HadwigerNelsonProblem.eq6", "source": "Sources/508.lean", "erdos_number": 508, "category_at_pin": "research open", "answer_form": null, "decl_name": "Erdos508.HadwigerNelsonProblem"}
+{"id": "Erdos508.HadwigerNelsonProblem.eq7", "source": "Sources/508.lean", "erdos_number": 508, "category_at_pin": "research open", "answer_form": null, "decl_name": "Erdos508.HadwigerNelsonProblem"}
 {"id": "Erdos52.erdos_52", "source": "Sources/52.lean", "erdos_number": 52, "category_at_pin": "research open", "answer_form": "lhs_sorry"}
 {"id": "Erdos564.erdos_564", "source": "Sources/564.lean", "erdos_number": 564, "category_at_pin": "research open", "answer_form": "lhs_sorry"}
 {"id": "Erdos595.erdos_595", "source": "Sources/595.lean", "erdos_number": 595, "category_at_pin": "research open", "answer_form": "lhs_sorry"}

--- a/apn/data/erdos/samples.jsonl
+++ b/apn/data/erdos/samples.jsonl
@@ -89,9 +89,9 @@
 {"id": "Erdos508.HadwigerNelsonAtLeast4", "source": "Sources/508.lean", "erdos_number": 508, "category_at_pin": "research solved", "answer_form": null}
 {"id": "Erdos508.HadwigerNelsonAtLeastFive", "source": "Sources/508.lean", "erdos_number": 508, "category_at_pin": "research solved", "answer_form": null}
 {"id": "Erdos508.HadwigerNelsonProblem", "source": "Sources/508.lean", "excluded": "value-typed answer(sorry): the placeholder elaborates to a position-labeled sorryAx in the statement's type, so the statement cannot be closed (or even stated) without the paper's google.answer \"with_auxiliary\" machinery, and SafeVerify cannot score it", "erdos_number": 508, "category_at_pin": "research open"}
-{"id": "Erdos508.HadwigerNelsonProblem.eq5", "source": "Sources/508.lean", "erdos_number": 508, "category_at_pin": "research open", "answer_form": null, "decl_name": "Erdos508.HadwigerNelsonProblem"}
-{"id": "Erdos508.HadwigerNelsonProblem.eq6", "source": "Sources/508.lean", "erdos_number": 508, "category_at_pin": "research open", "answer_form": null, "decl_name": "Erdos508.HadwigerNelsonProblem"}
-{"id": "Erdos508.HadwigerNelsonProblem.eq7", "source": "Sources/508.lean", "erdos_number": 508, "category_at_pin": "research open", "answer_form": null, "decl_name": "Erdos508.HadwigerNelsonProblem"}
+{"id": "Erdos508.HadwigerNelsonProblem.eq5", "source": "Sources/508.lean", "erdos_number": 508, "category_at_pin": "research open", "answer_form": null}
+{"id": "Erdos508.HadwigerNelsonProblem.eq6", "source": "Sources/508.lean", "erdos_number": 508, "category_at_pin": "research open", "answer_form": null}
+{"id": "Erdos508.HadwigerNelsonProblem.eq7", "source": "Sources/508.lean", "erdos_number": 508, "category_at_pin": "research open", "answer_form": null}
 {"id": "Erdos52.erdos_52", "source": "Sources/52.lean", "erdos_number": 52, "category_at_pin": "research open", "answer_form": "lhs_sorry"}
 {"id": "Erdos564.erdos_564", "source": "Sources/564.lean", "erdos_number": 564, "category_at_pin": "research open", "answer_form": "lhs_sorry"}
 {"id": "Erdos595.erdos_595", "source": "Sources/595.lean", "erdos_number": 595, "category_at_pin": "research open", "answer_form": "lhs_sorry"}

--- a/apn/data/erdos/subsets/bloom_selection.json
+++ b/apn/data/erdos/subsets/bloom_selection.json
@@ -1,5 +1,5 @@
 {
-  "description": "Thomas Bloom's Erdős problem statement selection: one representative statement per reviewed problem (ERDOS_PROBLEM_STATEMENT_SELECTION.md, reviewed at formal-conjectures 56534c04092446f2fd549d2865f2496924812da8). 47 of the 48 selected statements; the 48th, Erdos508.HadwigerNelsonProblem, is value-typed (χ(ℝ²) = answer(sorry), sorryAx in the statement type) and ships as an excluded manifest row. Statement text is vendored at the pinned commit (fc_commit), certified byte-identical to the review commit by scripts/erdos_statement_certificate.py (48/48 at vendor time; residual non-statement diffs in 8 files -- see that script's docstring). In problem-number order.",
+  "description": "Thomas Bloom's Erdős problem statement selection: one representative statement per reviewed problem (ERDOS_PROBLEM_STATEMENT_SELECTION.md, reviewed at formal-conjectures 56534c04092446f2fd549d2865f2496924812da8), except Problem 508, which contributes three derived prove-or-disprove samples (χ(ℝ²) = 5, 6, 7) in place of its value-typed HadwigerNelsonProblem (an excluded manifest row) -- 50 statements over 48 problems. Statement text is vendored at the pinned commit (fc_commit), certified byte-identical to the review commit by scripts/erdos_statement_certificate.py (48/48 at vendor time; residual non-statement diffs in 8 files -- see that script's docstring); the three 508 specs are derived from the vendored source by scripts/erdos_isolation.py's Hadwiger–Nelson special case. In problem-number order.",
   "ids": [
     "Erdos1.erdos_1",
     "Erdos3.erdos_3",
@@ -26,7 +26,7 @@
     "Erdos138.erdos_138",
     "Erdos172.erdos_172",
     "Erdos184.erdos_184",
-    "Erdos208.erdos_208.parts.ii",
+    "Erdos208.erdos_208.parts.i",
     "Erdos213.erdos_213",
     "Erdos241.erdos_241",
     "Erdos242.erdos_242",
@@ -35,6 +35,9 @@
     "Erdos371.erdos_371",
     "Erdos376.erdos_376",
     "Erdos406.erdos_406",
+    "Erdos508.HadwigerNelsonProblem.eq5",
+    "Erdos508.HadwigerNelsonProblem.eq6",
+    "Erdos508.HadwigerNelsonProblem.eq7",
     "Erdos564.erdos_564",
     "Erdos595.erdos_595",
     "Erdos647.erdos_647",

--- a/apn/data/erdos_autoformalized/NOTICE.md
+++ b/apn/data/erdos_autoformalized/NOTICE.md
@@ -5,3 +5,5 @@ Upstream source: the 18 `.lean` files in the root of `epoch-research/autoformali
 This is our own autoformalization output, not upstream formal-conjectures (the problems were chosen because they were absent from FC at the run's pin). `fc_commit` is the FC commit the run compiled against; it plays only its sandbox-image/proving-library role here.
 
 `samples.jsonl` lists every research-category statement in those files.
+
+`subsets/bloom_selection.json` lists the 18 statements Thomas Bloom's verdicts keep in the benchmark (1206 represented by part i alone; 1207 dropped entirely).

--- a/apn/data/erdos_autoformalized/NOTICE.md
+++ b/apn/data/erdos_autoformalized/NOTICE.md
@@ -6,4 +6,4 @@ This is our own autoformalization output, not upstream formal-conjectures (the p
 
 `samples.jsonl` lists every research-category statement in those files.
 
-`subsets/bloom_selection.json` lists the 18 statements Thomas Bloom's verdicts keep in the benchmark (1206 represented by part i alone; 1207 dropped entirely).
+`subsets/bloom_selection.json` lists the 18 statements Thomas Bloom's verdicts keep in the benchmark.

--- a/apn/data/erdos_autoformalized/subsets/bloom_selection.json
+++ b/apn/data/erdos_autoformalized/subsets/bloom_selection.json
@@ -1,0 +1,23 @@
+{
+  "description": "Thomas Bloom's verdicts on the autoformalized Erdős problems (2026-08-26): every manifest statement except Erdos1206.erdos_1206.parts.ii (part i alone represents Problem 1206) and Erdos1207.erdos_1207 (dropped from the benchmark entirely); Problem 713 stays split into its two parts as two samples. 18 statements over 17 problems. In problem-number order.",
+  "ids": [
+    "Erdos86.erdos_86",
+    "Erdos104.erdos_104",
+    "Erdos181.erdos_181",
+    "Erdos322.erdos_322",
+    "Erdos431.erdos_431",
+    "Erdos478.erdos_478",
+    "Erdos548.erdos_548",
+    "Erdos571.erdos_571",
+    "Erdos583.erdos_583",
+    "Erdos713.erdos_713.parts.i",
+    "Erdos713.erdos_713.parts.ii",
+    "Erdos714.erdos_714",
+    "Erdos773.erdos_773",
+    "Erdos970.erdos_970",
+    "Erdos1020.erdos_1020",
+    "Erdos1083.erdos_1083",
+    "Erdos1159.erdos_1159",
+    "Erdos1206.erdos_1206.parts.i"
+  ]
+}

--- a/apn/dataset.py
+++ b/apn/dataset.py
@@ -310,7 +310,10 @@ def erdos_dataset(names: list[str] | None = None) -> MemoryDataset:
     """The Erdős universe (the Bloom statement selection's 48 files) as Samples.
 
     Each sketch is the target's isolated spec followed by the derived
-    ``<target>.disproof`` declaration.
+    ``<target>.disproof`` declaration. Problem 508's value-typed member is an
+    excluded row; three derived prove-or-disprove samples (χ(ℝ²) = 5/6/7,
+    sharing its ``decl_name``) stand in for it -- see the Hadwiger–Nelson
+    special case in ``scripts/erdos_isolation.py``.
     """
     return build_dataset(ERDOS_DIR, "erdos", (), names)
 

--- a/apn/dataset.py
+++ b/apn/dataset.py
@@ -312,8 +312,8 @@ def erdos_dataset(names: list[str] | None = None) -> MemoryDataset:
     Each sketch is the target's isolated spec followed by the derived
     ``<target>.disproof`` declaration. Problem 508's value-typed member is an
     excluded row; three derived prove-or-disprove samples (χ(ℝ²) = 5/6/7,
-    sharing its ``decl_name``) stand in for it -- see the Hadwiger–Nelson
-    special case in ``scripts/erdos_isolation.py``.
+    each with a renamed ``...eqN`` target) stand in for it -- see the
+    Hadwiger–Nelson special case in ``scripts/erdos_isolation.py``.
     """
     return build_dataset(ERDOS_DIR, "erdos", (), names)
 

--- a/apn/dataset.py
+++ b/apn/dataset.py
@@ -311,9 +311,8 @@ def erdos_dataset(names: list[str] | None = None) -> MemoryDataset:
 
     Each sketch is the target's isolated spec followed by the derived
     ``<target>.disproof`` declaration. Problem 508's value-typed member is an
-    excluded row; three derived prove-or-disprove samples (χ(ℝ²) = 5/6/7,
-    each with a renamed ``...eqN`` target) stand in for it -- see the
-    Hadwiger–Nelson special case in ``scripts/erdos_isolation.py``.
+    excluded row with three derived prove-or-disprove samples in its place --
+    see the Hadwiger–Nelson special case in ``scripts/erdos_isolation.py``.
     """
     return build_dataset(ERDOS_DIR, "erdos", (), names)
 

--- a/apn/task.py
+++ b/apn/task.py
@@ -286,9 +286,8 @@ def apn_erdos_autoformalized(
 ) -> Task:
     """The Erdős problems our own autoformalization pipeline formalized.
 
-    The default ``bloom_selection`` subset applies Thomas Bloom's verdicts
-    (1206 represented by part i alone; 1207 dropped); ``subset=None`` runs the
-    full 20-statement manifest."""
+    The default ``bloom_selection`` subset applies Thomas Bloom's verdicts;
+    ``subset=None`` runs the full manifest."""
     name_list = (
         load_subset(ERDOS_AUTOFORMALIZED_DIR, subset) if subset is not None else None
     )

--- a/apn/task.py
+++ b/apn/task.py
@@ -278,13 +278,17 @@ def apn_erdos(
 
 @task
 def apn_erdos_autoformalized(
-    subset: str | None = None,
+    subset: str | None = "bloom_selection",
     gated: bool = True,
     literature: bool = False,
     agent_type: AgentType = "react",
     sandbox_backend: SandboxBackend = "docker",
 ) -> Task:
-    """The Erdős problems our own autoformalization pipeline formalized."""
+    """The Erdős problems our own autoformalization pipeline formalized.
+
+    The default ``bloom_selection`` subset applies Thomas Bloom's verdicts
+    (1206 represented by part i alone; 1207 dropped); ``subset=None`` runs the
+    full 20-statement manifest."""
     name_list = (
         load_subset(ERDOS_AUTOFORMALIZED_DIR, subset) if subset is not None else None
     )

--- a/configs/bloom68.yaml
+++ b/configs/bloom68.yaml
@@ -6,7 +6,7 @@
 retry_attempts: 5
 name: bloom68
 tasks:
-  - package: git+ssh://git@github.com/epoch-research/LeanOpenProblems.git@main
+  - package: git+ssh://git@github.com/epoch-research/LeanOpenProblems.git
     name: apn
     items:
       - name: apn_erdos
@@ -21,7 +21,7 @@ tasks:
           literature: true
 epochs: 1
 models:
-  - package: git+https://github.com/epoch-research/benchmarks@main
+  - package: git+https://github.com/epoch-research/benchmarks
     name: epoch
     items:
       - name: gpt-5.6-sol
@@ -64,6 +64,7 @@ secrets:
 runner:
   memory: 200Gi
   environment:
+    # TODO: Remove once default in Hawk
     INSPECT_LOG_CONDENSE: "true"
     ANTHROPIC_BASE_URL: https://api.anthropic.com
     OPENAI_BASE_URL: https://api.openai.com/v1
@@ -71,6 +72,7 @@ runner:
     HAWK_RUNNER_REFRESH_CLIENT_ID: ""
     HAWK_RUNNER_REFRESH_TOKEN: ''
 
-# Keep this aligned with epoch-research/benchmarks@main.
 packages:
+  # Right now needs to be kept in sync with epoch-research/benchmarks@main.
+  # TODO Remove once this wart is no longer necessary.
   - inspect-ai==0.3.259

--- a/configs/bloom68.yaml
+++ b/configs/bloom68.yaml
@@ -1,0 +1,102 @@
+# Schema reference for eval-set config:
+# https://github.com/METR/hawk/blob/main/hawk/api/EvalSetConfig.schema.json
+#
+# BLOOM68 -- the canonical run of Thomas Bloom's Erdős problem selection:
+# 68 samples over 65 distinct problems, the two `bloom_selection` subsets
+# combined (50 from apn_erdos + 18 from apn_erdos_autoformalized; see
+# apn/data/erdos/ERDOS_PROBLEM_STATEMENT_SELECTION.md and the subset files'
+# descriptions).
+#
+# Canonical harness conditions (TA recommendation, GB agreed, 2026-08-28):
+# maximum affordances, so results lower-bound what a model could do here.
+#   - agent_type: deep -- Inspect's deepagent loop; subagents (its main
+#     affordance) are enabled automatically.
+#   - literature: true -- the offline arXiv literature-snapshot image.
+# Neither condition measurably moved solve rates for current models on OEIS,
+# but they might help future models, and "all affordances" is the honest
+# canonical setting for an open-problems benchmark.
+name: bloom68
+tasks:
+  - package: git+ssh://git@github.com/epoch-research/LeanOpenProblems.git@main
+    name: apn
+    items:
+      # The subsets are these tasks' defaults; passed explicitly so this file
+      # fully determines the run.
+      - name: apn_erdos
+        args:
+          subset: bloom_selection
+          agent_type: deep
+          literature: true
+      - name: apn_erdos_autoformalized
+        args:
+          subset: bloom_selection
+          agent_type: deep
+          literature: true
+epochs: 1
+models:
+  # Epoch model wrappers (bypass middleman): API keys come straight from the
+  # secrets below; max_tokens/context window come from the package's models.yaml.
+  - package: git+https://github.com/epoch-research/benchmarks@giles-hawkbench-newstuff
+    name: epoch
+    items:
+      - name: gpt-5.6-sol
+        args:
+          config:
+            # Defaults to 'none' in GPT 5.4
+            reasoning_effort: "medium"
+            max_retries: 7
+            # max_sandboxes isn't user-settable; Hawk sizes it as
+            # 2 x sum(max_connections) across providers
+            max_connections: 40
+      - name: claude-fable-5
+        args:
+          config:
+            reasoning_effort: "high"
+            max_retries: 7
+            max_connections: 40
+
+# Per-sample spend cap -- the real budget. Requires model_cost_config below for
+# every model used, or Hawk/Inspect errors out.
+#
+# COST (2 models x 68 samples x 1 epoch = 136 samples, $100/sample cap):
+#   Max: 136 x $100 = $13,600   hard ceiling -- every sample hits its cap
+# Expected sits near max: runs are gated (default), so an unsolved problem
+# retries until it hits the cap, and the expected solve rate on this selection
+# is ~0% for current models.
+cost_limit: 100.0
+working_limit: 129_600  # 36 * 60 * 60
+
+# Prices in dollars per 1M tokens (from scripts/data/model_prices_and_context_window.json).
+# Keys must match Inspect's resolved <provider>/<model> names.
+model_cost_config:
+  epoch/gpt-5.6-sol:
+    input: 5.0
+    output: 30.0
+    input_cache_read: 0.5
+    input_cache_write: 6.25
+  epoch/claude-fable-5:
+    input: 10.0
+    output: 50.0
+    input_cache_read: 1.0
+    input_cache_write: 12.5
+
+secrets:
+  - name: ANTHROPIC_API_KEY
+  - name: OPENAI_API_KEY
+  - name: GOOGLE_API_KEY
+  - name: LEAN_OPEN_PROBLEMS_IMAGE_NAME
+    description: "The ECR repo containing the LeanOpenProblems sandbox images"
+
+runner:
+  memory: 200Gi
+  environment:
+    # TODO: Remove once default in Hawk
+    INSPECT_LOG_CONDENSE: "true"
+    ANTHROPIC_BASE_URL: https://api.anthropic.com
+    OPENAI_BASE_URL: https://api.openai.com/v1
+    GOOGLE_BASE_URL: https://generativelanguage.googleapis.com
+    HAWK_RUNNER_REFRESH_CLIENT_ID: ""
+    HAWK_RUNNER_REFRESH_TOKEN: ''
+
+packages:
+  - inspect-ai==0.3.245

--- a/configs/bloom68.yaml
+++ b/configs/bloom68.yaml
@@ -58,13 +58,13 @@ models:
 # Per-sample spend cap -- the real budget. Requires model_cost_config below for
 # every model used, or Hawk/Inspect errors out.
 #
-# COST (2 models x 68 samples x 1 epoch = 136 samples, $100/sample cap):
-#   Max: 136 x $100 = $13,600   hard ceiling -- every sample hits its cap
+# COST (2 models x 68 samples x 1 epoch = 136 samples, $200/sample cap):
+#   Max: 136 x $200 = $27,200   hard ceiling -- every sample hits its cap
 # Expected sits near max: runs are gated (default), so an unsolved problem
 # retries until it hits the cap, and the expected solve rate on this selection
 # is ~0% for current models.
-cost_limit: 100.0
-working_limit: 129_600  # 36 * 60 * 60
+cost_limit: 200.0
+working_limit: 259_200  # 72 * 60 * 60
 
 # Prices in dollars per 1M tokens (from scripts/data/model_prices_and_context_window.json).
 # Keys must match Inspect's resolved <provider>/<model> names.

--- a/configs/bloom68.yaml
+++ b/configs/bloom68.yaml
@@ -1,27 +1,14 @@
-# Schema reference for eval-set config:
-# https://github.com/METR/hawk/blob/main/hawk/api/EvalSetConfig.schema.json
+# Schema: https://github.com/METR/hawk/blob/main/hawk/api/EvalSetConfig.schema.json
 #
-# BLOOM68 -- the canonical run of Thomas Bloom's Erdős problem selection:
-# 68 samples over 65 distinct problems, the two `bloom_selection` subsets
-# combined (50 from apn_erdos + 18 from apn_erdos_autoformalized; see
-# apn/data/erdos/ERDOS_PROBLEM_STATEMENT_SELECTION.md and the subset files'
-# descriptions).
-#
-# Canonical harness conditions (TA recommendation, GB agreed, 2026-08-28):
-# maximum affordances, so results lower-bound what a model could do here.
-#   - agent_type: deep -- Inspect's deepagent loop; subagents (its main
-#     affordance) are enabled automatically.
-#   - literature: true -- the offline arXiv literature-snapshot image.
-# Neither condition measurably moved solve rates for current models on OEIS,
-# but they might help future models, and "all affordances" is the honest
-# canonical setting for an open-problems benchmark.
+# bloom68: the canonical run of Thomas Bloom's Erdős problem selection -- the
+# two bloom_selection subsets (50 + 18 samples), run with all affordances:
+# deep agent (subagents) + the offline literature snapshot (agreed 2026-08-28).
+retry_attempts: 5
 name: bloom68
 tasks:
   - package: git+ssh://git@github.com/epoch-research/LeanOpenProblems.git@main
     name: apn
     items:
-      # The subsets are these tasks' defaults; passed explicitly so this file
-      # fully determines the run.
       - name: apn_erdos
         args:
           subset: bloom_selection
@@ -34,19 +21,14 @@ tasks:
           literature: true
 epochs: 1
 models:
-  # Epoch model wrappers (bypass middleman): API keys come straight from the
-  # secrets below; max_tokens/context window come from the package's models.yaml.
-  - package: git+https://github.com/epoch-research/benchmarks@giles-hawkbench-newstuff
+  - package: git+https://github.com/epoch-research/benchmarks@main
     name: epoch
     items:
       - name: gpt-5.6-sol
         args:
           config:
-            # Defaults to 'none' in GPT 5.4
             reasoning_effort: "medium"
             max_retries: 7
-            # max_sandboxes isn't user-settable; Hawk sizes it as
-            # 2 x sum(max_connections) across providers
             max_connections: 40
       - name: claude-fable-5
         args:
@@ -55,19 +37,11 @@ models:
             max_retries: 7
             max_connections: 40
 
-# Per-sample spend cap -- the real budget. Requires model_cost_config below for
-# every model used, or Hawk/Inspect errors out.
-#
-# COST (2 models x 68 samples x 1 epoch = 136 samples, $200/sample cap):
-#   Max: 136 x $200 = $27,200   hard ceiling -- every sample hits its cap
-# Expected sits near max: runs are gated (default), so an unsolved problem
-# retries until it hits the cap, and the expected solve rate on this selection
-# is ~0% for current models.
+# 2 models x 68 samples x $200/sample cap = $27,200 max; gated runs sit near max.
 cost_limit: 200.0
 working_limit: 259_200  # 72 * 60 * 60
 
-# Prices in dollars per 1M tokens (from scripts/data/model_prices_and_context_window.json).
-# Keys must match Inspect's resolved <provider>/<model> names.
+# $ per 1M tokens; keys must match Inspect's resolved <provider>/<model> names.
 model_cost_config:
   epoch/gpt-5.6-sol:
     input: 5.0
@@ -90,7 +64,6 @@ secrets:
 runner:
   memory: 200Gi
   environment:
-    # TODO: Remove once default in Hawk
     INSPECT_LOG_CONDENSE: "true"
     ANTHROPIC_BASE_URL: https://api.anthropic.com
     OPENAI_BASE_URL: https://api.openai.com/v1
@@ -98,5 +71,6 @@ runner:
     HAWK_RUNNER_REFRESH_CLIENT_ID: ""
     HAWK_RUNNER_REFRESH_TOKEN: ''
 
+# Keep this aligned with epoch-research/benchmarks@main.
 packages:
-  - inspect-ai==0.3.245
+  - inspect-ai==0.3.259

--- a/configs/example-eval-set.yml
+++ b/configs/example-eval-set.yml
@@ -1,6 +1,5 @@
 # Schema reference for eval-set config:
 # https://github.com/METR/hawk/blob/main/hawk/api/EvalSetConfig.schema.json
-retry_attempts: 0  # Disable retries while we're still working out the kinks
 tasks:
   - package: git+ssh://git@github.com/epoch-research/LeanOpenProblems.git
     name: apn

--- a/scripts/erdos_isolation.py
+++ b/scripts/erdos_isolation.py
@@ -135,9 +135,10 @@ VERDICT_PROSE = [
 # bound), so the benchmark carries three derived prove-or-disprove samples in
 # its place, one per candidate value -- Greg Burnham's proposal, adopted by
 # Thomas Bloom (2026-08-25). Each spec is the source file cut down to the
-# target theorem with the `answer(sorry)` placeholder replaced by the literal.
-# The three samples share the declaration name, so their manifest rows carry
-# an explicit `decl_name` and the sample ids take an `.eqN` suffix.
+# target theorem with the `answer(sorry)` placeholder replaced by the literal
+# and the theorem renamed to `HadwigerNelsonProblem.eqN` -- so the three
+# statements carry distinct names and the id-is-the-declaration-name
+# convention holds.
 #
 # The derivation is pure text over the vendored source (no extractor run), so
 # generation and the fast suite (tests/test_erdos.py, byte-level re-derivation)
@@ -183,7 +184,11 @@ def derive_hadwiger_nelson_specs() -> dict[str, str]:
     for value, sample_id in zip(HN_VALUES, HN_SAMPLE_IDS):
         text, n = _HN_ANSWER_SORRY_RE.subn(str(value), base)
         assert n == 1, f"{sample_id}: {n} answer(sorry) substitutions"
-        specs[sample_id], _ = append_disproof(text, HN_DECL, HN_DECL)
+        old_header = "theorem HadwigerNelsonProblem :"
+        new_header = f"theorem HadwigerNelsonProblem.eq{value} :"
+        assert text.count(old_header) == 1, sample_id
+        text = text.replace(old_header, new_header)
+        specs[sample_id], _ = append_disproof(text, sample_id, sample_id)
     return specs
 
 
@@ -196,7 +201,6 @@ def hn_manifest_rows() -> list[dict]:
             "erdos_number": 508,
             "category_at_pin": "research open",
             "answer_form": None,
-            "decl_name": HN_DECL,
         }
         for sample_id in HN_SAMPLE_IDS
     ]

--- a/scripts/erdos_isolation.py
+++ b/scripts/erdos_isolation.py
@@ -26,7 +26,13 @@ from __future__ import annotations
 import re
 
 from scripts.fc_statements import strip_category_attrs
-from scripts.isolation import REPO, is_theorem_command
+from scripts.isolation import (
+    REPO,
+    append_disproof,
+    is_theorem_command,
+    strip_private,
+    tidy,
+)
 
 ERDOS_DIR = REPO / "apn" / "data" / "erdos"
 SOURCES_DIR = ERDOS_DIR / "Sources"
@@ -118,6 +124,82 @@ VERDICT_PROSE = [
     # un-filled; this sentence is that verdict in prose.
     "\n\nThe DeepMind prover agent has found a formal proof of this statement.\n",
 ]
+
+
+# --------------------------------------------------------------------------- #
+# The Hadwiger–Nelson special case (Problem 508).                              #
+# --------------------------------------------------------------------------- #
+# 508's only research-open statement, `HadwigerNelsonProblem`, is value-typed
+# (`χ(ℝ²) = answer(sorry)`) and ships as an excluded manifest row. χ(ℝ²) is
+# known to lie in {5, 6, 7} (de Grey's lower bound, Isbell's hexagonal upper
+# bound), so the benchmark carries three derived prove-or-disprove samples in
+# its place, one per candidate value -- Greg Burnham's proposal, adopted by
+# Thomas Bloom (2026-08-25). Each spec is the source file cut down to the
+# target theorem with the `answer(sorry)` placeholder replaced by the literal.
+# The three samples share the declaration name, so their manifest rows carry
+# an explicit `decl_name` and the sample ids take an `.eqN` suffix.
+#
+# The derivation is pure text over the vendored source (no extractor run), so
+# generation and the fast suite (tests/test_erdos.py, byte-level re-derivation)
+# both recompute it, and the container gates (compile, disproof certification)
+# cover the derived specs like every other spec in
+# tests/test_erdos_isolation.py -- which skips only the answer-form
+# certificate for them (the source statement is value-typed; there is no
+# rewrite form to certify) and asserts the derived statement's elaborated type
+# is sorryAx-free instead.
+HN_DECL = "Erdos508.HadwigerNelsonProblem"
+HN_VALUES = (5, 6, 7)
+HN_SAMPLE_IDS = tuple(f"{HN_DECL}.eq{v}" for v in HN_VALUES)
+
+# The target command's exact source text at the pin. Anchoring on the full
+# span keeps the derivation honest: if the pinned file drifts, generation and
+# the tests fail loudly here instead of silently deriving from something else.
+_HN_TARGET_COMMAND = """/--
+The Hadwiger–Nelson problem asks: How many colors are required to color the plane
+such that no two points at distance 1 from each other have the same color?
+-/
+@[category research open, AMS 52]
+theorem HadwigerNelsonProblem :
+    χ(ℝ²) = answer(sorry) := by
+  sorry
+"""
+
+_HN_ANSWER_SORRY_RE = re.compile(r"answer\(\s*sorry\s*\)")
+
+
+def derive_hadwiger_nelson_specs() -> dict[str, str]:
+    """The three derived Hadwiger–Nelson isolated specs, ``{sample id: text}``."""
+    src = (SOURCES_DIR / "508.lean").read_text()
+    idx = src.index(_HN_TARGET_COMMAND)
+    preamble = src[:idx]
+    # The target is the file's first theorem, so the preamble is exactly the
+    # header/module doc/opens/notation and everything after the target (the
+    # solved/textbook siblings) is dropped whole.
+    assert "theorem" not in preamble and "@[category" not in preamble
+    base, n_attrs = strip_category_attrs(preamble + _HN_TARGET_COMMAND)
+    assert n_attrs == 1
+    base = strip_private(tidy(base.encode()).decode())
+    specs: dict[str, str] = {}
+    for value, sample_id in zip(HN_VALUES, HN_SAMPLE_IDS):
+        text, n = _HN_ANSWER_SORRY_RE.subn(str(value), base)
+        assert n == 1, f"{sample_id}: {n} answer(sorry) substitutions"
+        specs[sample_id], _ = append_disproof(text, HN_DECL, HN_DECL)
+    return specs
+
+
+def hn_manifest_rows() -> list[dict]:
+    """Manifest rows for the three derived Hadwiger–Nelson samples."""
+    return [
+        {
+            "id": sample_id,
+            "source": "Sources/508.lean",
+            "erdos_number": 508,
+            "category_at_pin": "research open",
+            "answer_form": None,
+            "decl_name": HN_DECL,
+        }
+        for sample_id in HN_SAMPLE_IDS
+    ]
 
 
 def strip_fc_annotations(text: str) -> tuple[str, dict[str, int]]:

--- a/scripts/generate_erdos_isolated.py
+++ b/scripts/generate_erdos_isolated.py
@@ -17,7 +17,10 @@ definitions + the single target theorem and cuts every other standalone
 recorded-verdict ``answer(True/False)`` members, whose answer key must not
 leak -- and FC's recorded-verdict annotations are stripped (see
 ``scripts/erdos_isolation.py``; the rewrite's re-elaboration certificate lives
-in ``scripts/fc_statements.py`` / ``tests/test_erdos_isolation.py``). The
+in ``scripts/fc_statements.py`` / ``tests/test_erdos_isolation.py``). One
+special case: 508's excluded value-typed member additionally yields three
+derived prove-or-disprove specs, ``χ(ℝ²) = 5/6/7`` (the Hadwiger–Nelson
+special case in ``scripts/erdos_isolation.py``). The
 per-row ``answer_form``/``category_at_pin`` land in the manifest for tooling
 and tests; ``apn/dataset.py`` deliberately keeps them out of sample metadata.
 
@@ -52,6 +55,7 @@ from concurrent.futures import ThreadPoolExecutor
 from apn.dataset import fc_commit, fc_profile, write_manifest
 from scripts.erdos_isolation import (
     ERDOS_DIR,
+    HN_DECL,
     ISOLATED_DIR,
     PROVED_IN_FILE_REASON,
     RESEARCH_ATTR_RE,
@@ -59,6 +63,8 @@ from scripts.erdos_isolation import (
     SOURCES_DIR,
     VALUE_TYPED_REASON,
     VERDICT_PROSE,
+    derive_hadwiger_nelson_specs,
+    hn_manifest_rows,
     research_categories,
     strip_fc_annotations,
     universe_members,
@@ -204,6 +210,16 @@ def main() -> None:
             row["category_at_pin"] = category
             if "excluded" in row:
                 rows.append(row)
+                if decl["name"] == HN_DECL:
+                    # 508's value-typed member stays excluded, but the
+                    # benchmark carries three derived prove-or-disprove
+                    # samples (χ(ℝ²) = 5/6/7) in its place -- see the
+                    # Hadwiger–Nelson special case in scripts/erdos_isolation.py.
+                    for sample_id, text in derive_hadwiger_nelson_specs().items():
+                        (ISOLATED_DIR / f"{sample_id}.lean").write_text(text)
+                    hn_rows = hn_manifest_rows()
+                    rows.extend(hn_rows)
+                    forms[None] = forms.get(None, 0) + len(hn_rows)
                 continue
 
             closure = dependency_closure(filerec, decl["name"])

--- a/tests/test_erdos.py
+++ b/tests/test_erdos.py
@@ -5,9 +5,10 @@ elaboration, the certified per-form ``answer(...) ↔`` rewrite, only the target
 + its dependency decls surviving -- are enforced authoritatively, in a
 container, by ``tests/test_erdos_isolation.py``. This module checks what can
 be checked cheaply on every run: the manifest census (every research-category
-statement of the Bloom selection's 48 vendored files), the ``bloom_selection``
-subset (the 47 scoreable selected statements, ``apn_erdos``'s default), the
-dataset/sample shape, and textual invariants of the shipped sketches.
+statement of the Bloom selection's 48 vendored files, plus the three derived
+Hadwiger–Nelson samples), the ``bloom_selection`` subset (the 50 scoreable
+selected statements, ``apn_erdos``'s default), the dataset/sample shape, and
+textual invariants of the shipped sketches.
 """
 
 from __future__ import annotations
@@ -25,9 +26,12 @@ from apn.dataset import (
     load_subset,
 )
 from scripts.erdos_isolation import (
+    HN_DECL,
+    HN_SAMPLE_IDS,
     PROVED_IN_FILE_REASON,
     SORRY_ALLOWLIST_FILES,
     VALUE_TYPED_REASON,
+    derive_hadwiger_nelson_specs,
 )
 from scripts.isolation import matches_name
 
@@ -39,9 +43,10 @@ _SORRY_RE = re.compile(r"\bsorry\b")
 _DECL_RE = re.compile(r"(?m)^(?:protected\s+)?(?:theorem|lemma)\s+([^\s:({\[⦃]+)")
 
 # The Bloom selection (apn/data/erdos/ERDOS_PROBLEM_STATEMENT_SELECTION.md):
-# selected statement's short name per problem number. 508's selection is the
-# excluded value-typed HadwigerNelsonProblem, so the *scoreable* selection --
-# the bloom_selection subset -- is the other 47.
+# selected statement's short name per problem number. 508's reviewed statement
+# is the excluded value-typed HadwigerNelsonProblem; the *scoreable* selection
+# -- the bloom_selection subset -- carries its three derived prove-or-disprove
+# samples (HN_SAMPLE_IDS) in its place, 50 statements in all.
 SELECTED = {
     1: "erdos_1", 3: "erdos_3", 5: "erdos_5", 7: "erdos_7", 20: "erdos_20",
     23: "erdos_23", 28: "erdos_28", 30: "erdos_30", 39: "erdos_39",
@@ -49,7 +54,7 @@ SELECTED = {
     68: "erdos_68", 74: "erdos_74", 89: "erdos_89", 97: "erdos_97",
     101: "erdos_101", 107: "erdos_107", 120: "erdos_120", 126: "erdos_126",
     128: "erdos_128", 138: "erdos_138", 172: "erdos_172", 184: "erdos_184",
-    208: "erdos_208.parts.ii", 213: "erdos_213", 241: "erdos_241",
+    208: "erdos_208.parts.i", 213: "erdos_213", 241: "erdos_241",
     242: "erdos_242", 324: "erdos_324", 364: "erdos_364", 371: "erdos_371",
     376: "erdos_376", 406: "erdos_406", 508: "HadwigerNelsonProblem",
     564: "erdos_564", 595: "erdos_595", 647: "erdos_647", 672: "erdos_672",
@@ -70,9 +75,10 @@ def _selected_row(rows: list[SampleRow], number: int) -> SampleRow:
 
 def test_manifest_census() -> None:
     # The universe: every research-category statement of the 48 vendored
-    # files -- the selected statements plus their research variants.
+    # files -- the selected statements plus their research variants -- plus
+    # the three derived Hadwiger–Nelson samples.
     rows = load_manifest(ERDOS_DIR)
-    assert len(rows) == 144
+    assert len(rows) == 147
     assert {r.extra["erdos_number"] for r in rows} == set(SELECTED)
     excluded = {r.id: r.excluded for r in rows if r.excluded is not None}
     assert excluded == {
@@ -103,7 +109,7 @@ def test_manifest_answer_form_census() -> None:
     # re-checked per member in tests/test_erdos_isolation.py.)
     forms = Counter(r.extra["answer_form"] for r in load_manifest(ERDOS_DIR) if r.excluded is None)
     assert forms == {
-        None: 87,
+        None: 90,
         "lhs_sorry": 52,
         "lhs_true": 2,
     }
@@ -117,12 +123,13 @@ def test_spec_files_match_manifest_exactly() -> None:
 
 
 def test_bloom_selection_subset() -> None:
-    # The default subset: the 47 scoreable selected statements -- exactly one
-    # per reviewed problem except 508, each `research open` at the pin.
+    # The default subset: the 50 scoreable selected statements -- exactly one
+    # per reviewed problem, except 508's three derived samples -- each
+    # `research open` at the pin.
     rows = load_manifest(ERDOS_DIR)
     ids = load_subset(ERDOS_DIR, "bloom_selection")
-    assert len(ids) == 47
-    assert len(set(ids)) == 47
+    assert len(ids) == 50
+    assert len(set(ids)) == 50
     by_id = {r.id: r for r in rows}
     numbers = []
     for sample_id in ids:
@@ -130,9 +137,12 @@ def test_bloom_selection_subset() -> None:
         assert row.excluded is None, sample_id
         assert row.extra["category_at_pin"] == "research open", sample_id
         numbers.append(row.extra["erdos_number"])
-        assert matches_name(sample_id, SELECTED[row.extra["erdos_number"]]), sample_id
-    assert sorted(numbers) == sorted(set(SELECTED) - {508})
-    assert len(erdos_dataset(names=ids)) == 47
+        if row.extra["erdos_number"] == 508:
+            assert sample_id in HN_SAMPLE_IDS, sample_id
+        else:
+            assert matches_name(sample_id, SELECTED[row.extra["erdos_number"]]), sample_id
+    assert Counter(numbers) == Counter(set(SELECTED) - {508}) + Counter({508: 3})
+    assert len(erdos_dataset(names=ids)) == 50
 
 
 def test_508_ships_as_excluded_value_typed_row() -> None:
@@ -145,6 +155,25 @@ def test_508_ships_as_excluded_value_typed_row() -> None:
     assert row.excluded == VALUE_TYPED_REASON
 
 
+def test_508_derived_samples() -> None:
+    # In the excluded row's place, the benchmark carries three derived
+    # prove-or-disprove samples, χ(ℝ²) = 5/6/7 (Bloom's verdict, 2026-08-25;
+    # see the Hadwiger–Nelson special case in scripts/erdos_isolation.py).
+    # The committed specs must match the pure-text re-derivation byte for
+    # byte; their elaboration soundness (compile, certified disproof) is
+    # tests/test_erdos_isolation.py's job.
+    rows = {r.id: r for r in load_manifest(ERDOS_DIR)}
+    specs = derive_hadwiger_nelson_specs()
+    assert set(specs) == set(HN_SAMPLE_IDS)
+    for sample_id, text in specs.items():
+        row = rows[sample_id]
+        assert row.excluded is None
+        assert row.decl_name == HN_DECL
+        assert row.extra["answer_form"] is None
+        assert row.extra["category_at_pin"] == "research open"
+        assert (ERDOS_DIR / row.statement_path).read_text() == text
+
+
 def test_every_selected_statement_is_research_open_at_pin() -> None:
     rows = load_manifest(ERDOS_DIR)
     for number in SELECTED:
@@ -154,7 +183,7 @@ def test_every_selected_statement_is_research_open_at_pin() -> None:
 
 def test_erdos_dataset_loads_all_samples() -> None:
     ds = erdos_dataset()
-    assert len(ds) == 141
+    assert len(ds) == 144
     ids = [s.id for s in ds]
     assert len(set(ids)) == len(ids)
 
@@ -279,6 +308,8 @@ def test_no_sibling_member_survives_in_any_spec() -> None:
     # excluded) may survive in another member's spec beyond the documented
     # dependency-kept few. Pure-Python guard over the committed files; the
     # authoritative re-extraction check lives in tests/test_erdos_isolation.py.
+    # Identity is the row's *declaration* name: the three derived
+    # Hadwiger–Nelson samples share HN_DECL under distinct sample ids.
     rows = load_manifest(ERDOS_DIR)
     all_ids = [r.id for r in rows]
     for row in rows:
@@ -286,9 +317,9 @@ def test_no_sibling_member_survives_in_any_spec() -> None:
             continue
         text = (ERDOS_DIR / row.statement_path).read_text()
         declared = _DECL_RE.findall(text)
-        assert any(_declares(row.id, n) for n in declared), row.id
+        assert any(_declares(row.decl_name, n) for n in declared), row.id
         for name in declared:
-            if _declares(row.id, name):
+            if _declares(row.decl_name, name):
                 continue
             offenders = [
                 i for i in all_ids

--- a/tests/test_erdos.py
+++ b/tests/test_erdos.py
@@ -26,7 +26,6 @@ from apn.dataset import (
     load_subset,
 )
 from scripts.erdos_isolation import (
-    HN_DECL,
     HN_SAMPLE_IDS,
     PROVED_IN_FILE_REASON,
     SORRY_ALLOWLIST_FILES,
@@ -168,7 +167,7 @@ def test_508_derived_samples() -> None:
     for sample_id, text in specs.items():
         row = rows[sample_id]
         assert row.excluded is None
-        assert row.decl_name == HN_DECL
+        assert row.decl_name == sample_id  # the derivation renames the target
         assert row.extra["answer_form"] is None
         assert row.extra["category_at_pin"] == "research open"
         assert (ERDOS_DIR / row.statement_path).read_text() == text
@@ -308,8 +307,6 @@ def test_no_sibling_member_survives_in_any_spec() -> None:
     # excluded) may survive in another member's spec beyond the documented
     # dependency-kept few. Pure-Python guard over the committed files; the
     # authoritative re-extraction check lives in tests/test_erdos_isolation.py.
-    # Identity is the row's *declaration* name: the three derived
-    # Hadwiger–Nelson samples share HN_DECL under distinct sample ids.
     rows = load_manifest(ERDOS_DIR)
     all_ids = [r.id for r in rows]
     for row in rows:
@@ -317,9 +314,9 @@ def test_no_sibling_member_survives_in_any_spec() -> None:
             continue
         text = (ERDOS_DIR / row.statement_path).read_text()
         declared = _DECL_RE.findall(text)
-        assert any(_declares(row.decl_name, n) for n in declared), row.id
+        assert any(_declares(row.id, n) for n in declared), row.id
         for name in declared:
-            if _declares(row.decl_name, name):
+            if _declares(row.id, name):
                 continue
             offenders = [
                 i for i in all_ids

--- a/tests/test_erdos_autoformalized.py
+++ b/tests/test_erdos_autoformalized.py
@@ -21,6 +21,7 @@ from apn.dataset import (
     ERDOS_AUTOFORMALIZED_DIR,
     erdos_autoformalized_dataset,
     load_manifest,
+    load_subset,
 )
 from scripts.fc_statements import strip_comments
 from scripts.isolation import disproof_declaration
@@ -79,6 +80,19 @@ def test_manifest_census() -> None:
         1206,
         1207,
     }
+
+
+def test_bloom_selection_subset() -> None:
+    # Thomas Bloom's verdicts (2026-08-26), apn_erdos_autoformalized's default
+    # subset: Problem 1206 is represented by part i alone, 1207 is dropped
+    # from the benchmark entirely, and 713 stays split into its two parts.
+    ids = load_subset(ERDOS_AUTOFORMALIZED_DIR, "bloom_selection")
+    assert len(ids) == 18
+    assert set(ids) == EXPECTED_IDS - {
+        "Erdos1206.erdos_1206.parts.ii",
+        "Erdos1207.erdos_1207",
+    }
+    assert len(erdos_autoformalized_dataset(names=ids)) == 18
 
 
 def test_manifest_row_shape() -> None:

--- a/tests/test_erdos_isolation.py
+++ b/tests/test_erdos_isolation.py
@@ -47,6 +47,7 @@ import pytest_asyncio
 
 from apn.dataset import ERDOS_DIR, SampleRow, fc_commit, fc_profile, load_manifest
 from scripts.erdos_isolation import (
+    HN_DECL,
     HN_SAMPLE_IDS,
     ISOLATED_DIR,
     SOURCES_DIR,
@@ -145,11 +146,14 @@ async def test_isolated_files_are_structurally_correct(
     rewritten forms."""
     failures: list[str] = []
     for row in kept_rows:
-        # The target's declaration name (== the sample id everywhere except
-        # the three derived Hadwiger–Nelson samples, which share HN_DECL).
-        name, rel = row.decl_name, row.source.removeprefix("Sources/")
+        name, rel = row.id, row.source.removeprefix("Sources/")
         stem = row.statement_path.removeprefix("Isolated/").removesuffix(".lean")
-        src_type, planned = planned_survivors(iso_data.src_ranges[rel], name)
+        # The derived Hadwiger–Nelson samples rename their source declaration
+        # (HN_DECL) to the sample's own name, so the cut prediction resolves
+        # the source name and is mapped through the rename.
+        src_name = HN_DECL if row.id in HN_SAMPLE_IDS else name
+        src_type, planned = planned_survivors(iso_data.src_ranges[rel], src_name)
+        planned = [name if d == src_name else d for d in planned]
         src_type = normalize_hygiene(src_type)
         fr = iso_data.iso_ranges.get(stem)
         if fr is None:

--- a/tests/test_erdos_isolation.py
+++ b/tests/test_erdos_isolation.py
@@ -47,6 +47,7 @@ import pytest_asyncio
 
 from apn.dataset import ERDOS_DIR, SampleRow, fc_commit, fc_profile, load_manifest
 from scripts.erdos_isolation import (
+    HN_SAMPLE_IDS,
     ISOLATED_DIR,
     SOURCES_DIR,
 )
@@ -144,19 +145,21 @@ async def test_isolated_files_are_structurally_correct(
     rewritten forms."""
     failures: list[str] = []
     for row in kept_rows:
-        name, rel = row.id, row.source.removeprefix("Sources/")
+        # The target's declaration name (== the sample id everywhere except
+        # the three derived Hadwiger–Nelson samples, which share HN_DECL).
+        name, rel = row.decl_name, row.source.removeprefix("Sources/")
         stem = row.statement_path.removeprefix("Isolated/").removesuffix(".lean")
         src_type, planned = planned_survivors(iso_data.src_ranges[rel], name)
         src_type = normalize_hygiene(src_type)
         fr = iso_data.iso_ranges.get(stem)
         if fr is None:
-            failures.append(f"{name}: no isolated file extracted")
+            failures.append(f"{row.id}: no isolated file extracted")
             continue
         thms = theorem_command_decls(fr)
         target_hits = [d for d in thms if d["name"] == name]
         if len(target_hits) != 1:
             failures.append(
-                f"{name}: target appears {len(target_hits)}x among {[d['name'] for d in thms]}"
+                f"{row.id}: target appears {len(target_hits)}x among {[d['name'] for d in thms]}"
             )
             continue
         remaining = sorted(d["name"] for d in thms)
@@ -164,17 +167,27 @@ async def test_isolated_files_are_structurally_correct(
         # `.disproof` declaration (comparator-migration-plan.md §4).
         expected = sorted(planned + [f"{row.decl_name}.disproof"])
         if remaining != expected:
-            failures.append(f"{name}: surviving theorems {remaining} != expected {expected}")
+            failures.append(f"{row.id}: surviving theorems {remaining} != expected {expected}")
+            continue
+        iso_type = normalize_hygiene(target_hits[0]["type"])
+        if row.id in HN_SAMPLE_IDS:
+            # Derived Hadwiger–Nelson samples: the source statement is
+            # value-typed, so there is no answer(...) ↔ form to certify (the
+            # byte-level re-derivation check lives in tests/test_erdos.py).
+            # Assert the derived statement elaborates placeholder-free instead.
+            if row.extra["answer_form"] is not None:
+                failures.append(f"{row.id}: derived sample carries an answer_form")
+            elif "sorryAx" in iso_type:
+                failures.append(f"{row.id}: sorryAx in the derived statement's type")
             continue
         form = _source_form(name, rel, iso_data.src_ranges[rel])
         if form != row.extra["answer_form"]:
             failures.append(
-                f"{name}: manifest answer_form {row.extra['answer_form']} != source's {form}"
+                f"{row.id}: manifest answer_form {row.extra['answer_form']} != source's {form}"
             )
             continue
-        iso_type = normalize_hygiene(target_hits[0]["type"])
         if not answer_certified(form, src_type, iso_type):
-            failures.append(f"{name}: target statement changed during isolation ({form=})")
+            failures.append(f"{row.id}: target statement changed during isolation ({form=})")
     assert not failures, "structural validation failed:\n  " + "\n  ".join(failures)
 
 


### PR DESCRIPTION
Applies Thomas Bloom's verdicts (emails of 2026-08-25/26) to the two Erdős datasets, and adds the canonical run config. With both `bloom_selection` subsets in effect, the benchmark totals **68 samples over 65 distinct problems**: 50 in `erdos` (508 contributes three samples) + 18 in `erdos_autoformalized` (713 contributes two).

## erdos (FC-formalized, 48 problems)

- **208 → `erdos_208.parts.i`**: Bloom's explicit pick, overriding the earlier "stronger part" choice of `parts.ii`. (812 stays `parts.i`, already his pick.)
- **508 (Hadwiger–Nelson) resurrected as three samples**: the value-typed `HadwigerNelsonProblem` stays an excluded manifest row, and three derived prove-or-disprove samples — χ(ℝ²) = 5, = 6, = 7 — stand in for it (Greg's proposal, adopted by Bloom). The derivation is a pure-text special case in `scripts/erdos_isolation.py`: the vendored `Sources/508.lean` stays byte-identical to the FC pin (the statement certificate is untouched), the target theorem is cut out, its `answer(sorry)` placeholder replaced by the literal, and the theorem renamed to `HadwigerNelsonProblem.eqN` — so each sample's id is its declaration name, per the usual convention. The fast suite re-derives the committed specs byte-for-byte; the container suite compiles them and certifies their `.disproof` declarations like every other spec (it skips only the answer-form certificate, which cannot apply to a value-typed source, and asserts the derived statement's type is sorryAx-free instead).
- `bloom_selection` is now **50 statements over 48 problems**.
- `ERDOS_PROBLEM_STATEMENT_SELECTION.md` cut down to the selection rules plus Bloom's full list of 70 problem numbers; the per-problem table is redundant with `subsets/bloom_selection.json`.

## erdos_autoformalized (18 problems, 20 statements)

- New `subsets/bloom_selection.json`, now `apn_erdos_autoformalized`'s default subset: **18 statements** — drops `Erdos1206.erdos_1206.parts.ii` (part i alone represents 1206) and `Erdos1207.erdos_1207` (dropped from the benchmark entirely); 713 stays split into two samples. The manifest and vendored files are untouched.

## configs/bloom68.yaml

The canonical eval-set config for the selection (the first git-tracked file in `configs/`): both tasks with their `bloom_selection` subsets, run with all affordances — `agent_type: deep` (subagents) and `literature: true` (offline arXiv snapshot) — per the 2026-08-28 agreement. gpt-5.6-sol + claude-fable-5, $200/sample cap (agreed; $27.2k hard ceiling), aligned with the recently launched configs (`benchmarks@main`, `inspect-ai==0.3.259`, `retry_attempts: 5`). Points at `LeanOpenProblems@main`, so launch after merge.

## Notes for review

- Exactly one of χ(ℝ²)=5/6/7 is true, so two of the three 508 samples are disprovable-in-principle statements — worth keeping in mind when counting solve rates.
- The three derived specs have not been compiled locally (no local Lean toolchain); CI's isolation suite is the authoritative gate. `χ(ℝ²) = 5` needs `OfNat ℕ∞ 5`, which Mathlib has, so this should be routine.
- Fast suites and mypy pass locally.