### PR TITLE
Add canonical OEIS Open Lite config (basic agent, $200/sample)

### DIFF
--- a/configs/bloom68.yaml
+++ b/configs/bloom68.yaml
@@ -3,7 +3,6 @@
 # bloom68: the canonical run of Thomas Bloom's Erdős problem selection -- the
 # two bloom_selection subsets (50 + 18 samples), run with all affordances:
 # deep agent (subagents) + the offline literature snapshot (agreed 2026-08-28).
-retry_attempts: 5
 name: bloom68
 tasks:
   - package: git+ssh://git@github.com/epoch-research/LeanOpenProblems.git
@@ -19,7 +18,6 @@ tasks:
           subset: bloom_selection
           agent_type: deep
           literature: true
-epochs: 1
 models:
   - package: git+https://github.com/epoch-research/benchmarks
     name: epoch
@@ -27,17 +25,13 @@ models:
       - name: gpt-5.6-sol
         args:
           config:
-            reasoning_effort: "medium"
-            max_retries: 7
-            max_connections: 40
-      - name: claude-fable-5
-        args:
-          config:
-            reasoning_effort: "high"
+            # Our policy is to use the highest reasoning effort the model
+            # supports (thinking_settings in benchmarks bench/model/epoch/models.yaml).
+            reasoning_effort: "max"
             max_retries: 7
             max_connections: 40
 
-# 2 models x 68 samples x $200/sample cap = $27,200 max; gated runs sit near max.
+# 1 model x 68 samples x $200/sample cap = $13,600 max; gated runs sit near max.
 cost_limit: 200.0
 working_limit: 259_200  # 72 * 60 * 60
 
@@ -48,11 +42,6 @@ model_cost_config:
     output: 30.0
     input_cache_read: 0.5
     input_cache_write: 6.25
-  epoch/claude-fable-5:
-    input: 10.0
-    output: 50.0
-    input_cache_read: 1.0
-    input_cache_write: 12.5
 
 secrets:
   - name: ANTHROPIC_API_KEY

--- a/configs/bloom68.yaml
+++ b/configs/bloom68.yaml
@@ -25,8 +25,7 @@ models:
       - name: gpt-5.6-sol
         args:
           config:
-            # Our policy is to use the highest reasoning effort the model
-            # supports (thinking_settings in benchmarks bench/model/epoch/models.yaml).
+            # Policy: use the highest reasoning effort the model supports.
             reasoning_effort: "max"
             max_retries: 7
             max_connections: 40

--- a/configs/oeis-open-lite.yaml
+++ b/configs/oeis-open-lite.yaml
@@ -4,7 +4,6 @@
 # 100-conjecture random draw from the 492 OEIS Open Problems
 # (apn/data/oeis/subsets/lite.json), run with the basic agent (react, no
 # subagents, no literature snapshot).
-retry_attempts: 5
 name: oeis-open-lite
 tasks:
   - package: git+ssh://git@github.com/epoch-research/LeanOpenProblems.git
@@ -15,7 +14,6 @@ tasks:
           subset: lite
           agent_type: react
           literature: false
-epochs: 1
 models:
   - package: git+https://github.com/epoch-research/benchmarks
     name: epoch
@@ -23,17 +21,10 @@ models:
       - name: gpt-5.6-sol
         args:
           config:
-            reasoning_effort: "medium"
-            max_retries: 7
-            max_connections: 40
-      - name: claude-fable-5
-        args:
-          config:
-            reasoning_effort: "high"
             max_retries: 7
             max_connections: 40
 
-# 2 models x 100 samples x $200/sample cap = $40,000 max; gated runs sit near max.
+# 1 model x 100 samples x $200/sample cap = $20,000 max; gated runs sit near max.
 cost_limit: 200.0
 working_limit: 259_200  # 72 * 60 * 60
 
@@ -44,11 +35,6 @@ model_cost_config:
     output: 30.0
     input_cache_read: 0.5
     input_cache_write: 6.25
-  epoch/claude-fable-5:
-    input: 10.0
-    output: 50.0
-    input_cache_read: 1.0
-    input_cache_write: 12.5
 
 secrets:
   - name: ANTHROPIC_API_KEY

--- a/configs/oeis-open-lite.yaml
+++ b/configs/oeis-open-lite.yaml
@@ -1,0 +1,74 @@
+# Schema: https://github.com/METR/hawk/blob/main/hawk/api/EvalSetConfig.schema.json
+#
+# oeis-open-lite: the canonical run of the OEIS Open Lite subset -- the
+# 100-conjecture random draw from the 492 OEIS Open Problems
+# (apn/data/oeis/subsets/lite.json), run with the basic agent (react, no
+# subagents, no literature snapshot).
+retry_attempts: 5
+name: oeis-open-lite
+tasks:
+  - package: git+ssh://git@github.com/epoch-research/LeanOpenProblems.git
+    name: apn
+    items:
+      - name: apn_oeis
+        args:
+          subset: lite
+          agent_type: react
+          literature: false
+epochs: 1
+models:
+  - package: git+https://github.com/epoch-research/benchmarks
+    name: epoch
+    items:
+      - name: gpt-5.6-sol
+        args:
+          config:
+            reasoning_effort: "medium"
+            max_retries: 7
+            max_connections: 40
+      - name: claude-fable-5
+        args:
+          config:
+            reasoning_effort: "high"
+            max_retries: 7
+            max_connections: 40
+
+# 2 models x 100 samples x $200/sample cap = $40,000 max; gated runs sit near max.
+cost_limit: 200.0
+working_limit: 259_200  # 72 * 60 * 60
+
+# $ per 1M tokens; keys must match Inspect's resolved <provider>/<model> names.
+model_cost_config:
+  epoch/gpt-5.6-sol:
+    input: 5.0
+    output: 30.0
+    input_cache_read: 0.5
+    input_cache_write: 6.25
+  epoch/claude-fable-5:
+    input: 10.0
+    output: 50.0
+    input_cache_read: 1.0
+    input_cache_write: 12.5
+
+secrets:
+  - name: ANTHROPIC_API_KEY
+  - name: OPENAI_API_KEY
+  - name: GOOGLE_API_KEY
+  - name: LEAN_OPEN_PROBLEMS_IMAGE_NAME
+    description: "The ECR repo containing the LeanOpenProblems sandbox images"
+
+runner:
+  memory: 200Gi
+  environment:
+    # TODO: Remove once default in Hawk
+    INSPECT_LOG_CONDENSE: "true"
+    ANTHROPIC_BASE_URL: https://api.anthropic.com
+    OPENAI_BASE_URL: https://api.openai.com/v1
+    GOOGLE_BASE_URL: https://generativelanguage.googleapis.com
+    HAWK_RUNNER_REFRESH_CLIENT_ID: ""
+    HAWK_RUNNER_REFRESH_TOKEN: ''
+
+packages:
+  # Right now needs to be kept in sync with epoch-research/benchmarks@main.
+  # TODO Remove once this wart is no longer necessary.
+  - inspect-ai==0.3.259

--- a/configs/oeis-open-lite.yaml
+++ b/configs/oeis-open-lite.yaml
@@ -1,9 +1,7 @@
 # Schema: https://github.com/METR/hawk/blob/main/hawk/api/EvalSetConfig.schema.json
 #
-# oeis-open-lite: the canonical run of the OEIS Open Lite subset -- the
-# 100-conjecture random draw from the 492 OEIS Open Problems
-# (apn/data/oeis/subsets/lite.json), run with the basic agent (react, no
-# subagents, no literature snapshot).
+# oeis-open-lite: canonical run of the OEIS Open Lite subset -- 100 random
+# conjectures from the 492 OEIS Open Problems, with the basic agent.
 name: oeis-open-lite
 tasks:
   - package: git+ssh://git@github.com/epoch-research/LeanOpenProblems.git


### PR DESCRIPTION
Adds `configs/oeis-open-lite.yaml`: the canonical eval-set config for the OEIS Open Lite subset run with the basic agent (`agent_type: react`, no literature snapshot).

Both this config and `configs/bloom68.yaml` are simplified to a single model, `gpt-5.6-sol`, and drop `epochs` and `retry_attempts` (both defaults):

- bloom68 sets `reasoning_effort: "max"` — the model's highest supported value — with a comment that this is our policy.
- oeis-open-lite leaves reasoning effort unspecified (model default).
- Cost comments updated: bloom68 max is now $13,600 (68 × $200), oeis-open-lite is $20,000 (100 × $200).