### PR TITLE
Run tini as PID 1 in sandbox containers, so orphans get reaped

### DIFF
--- a/apn/__init__.py
+++ b/apn/__init__.py
@@ -1,4 +1,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"

--- a/apn/lean/Dockerfile
+++ b/apn/lean/Dockerfile
@@ -186,8 +186,9 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # agent_corpus, comparator, generate) builds FROM this stage, and the sandbox
 # entrypoint/command is shared (apn.task.SANDBOX_COMMAND), so a service whose
 # image lacked tini would fail to start at all. It exists only to run as a
-# reaping PID 1 -- see the SANDBOX_COMMAND comment in apn/task.py and
-# https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/issues/251.
+# reaping PID 1 (see the SANDBOX_COMMAND comment in apn/task.py). TODO:
+# remove it if the upstream issue is fixed:
+# https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/issues/251
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl git ca-certificates build-essential libgmp-dev \
         python3 python3-pip tini \

--- a/apn/lean/Dockerfile
+++ b/apn/lean/Dockerfile
@@ -182,10 +182,15 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # Runtime libs for the Lean toolchain, plus the build tools the derived images
 # need (the agent builds PyPantograph; the comparator image builds lean4export)
 # and python3 (the agent uses it to drive PyPantograph and as a numerical
-# scratchpad).
+# scratchpad). tini belongs HERE, in base: every service image (agent,
+# agent_corpus, comparator, generate) builds FROM this stage, and the sandbox
+# entrypoint/command is shared (apn.task.SANDBOX_COMMAND), so a service whose
+# image lacked tini would fail to start at all. It exists only to run as a
+# reaping PID 1 -- see the SANDBOX_COMMAND comment in apn/task.py and
+# https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/issues/251.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl git ca-certificates build-essential libgmp-dev \
-        python3 python3-pip \
+        python3 python3-pip tini \
     && rm -rf /var/lib/apt/lists/*
 
 # The Lean/lake toolchain (binaries + the project toolchain). The image ENV PATH

--- a/apn/task.py
+++ b/apn/task.py
@@ -62,8 +62,8 @@ COMPARATOR_MEMORY_GIB = 32
 # backend tini must be the command itself. tini exists only to reap; `-s`
 # (subreaper) keeps it correct where it is not PID 1 -- the local-docker case.
 #
-# This is a workaround. Reported upstream, so remove this (and the tini
-# install in apn/lean/Dockerfile's base stage) if it is fixed there:
+# This is a workaround. TODO: remove this (and the tini install in
+# apn/lean/Dockerfile's base stage) if it is fixed upstream:
 # https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/issues/251
 SANDBOX_COMMAND = ["/usr/bin/tini", "-s", "--", "tail", "-f", "/dev/null"]
 

--- a/apn/task.py
+++ b/apn/task.py
@@ -52,6 +52,21 @@ SandboxBackend = Literal["docker", "k8s"]
 AGENT_MEMORY_GIB = 32
 COMPARATOR_MEMORY_GIB = 32
 
+# Both backends' long-lived main process, wrapped in a reaping PID 1. A bare
+# `tail -f /dev/null` never calls wait(), so every process a sandbox exec
+# orphans is reparented to PID 1 and stays a zombie holding its process slot
+# for the life of the container, until fork() returns EAGAIN and every later
+# command in the sample fails. Local Docker is immune (`init: true` below puts
+# docker-init above tail), but Kubernetes has no init equivalent and the
+# agent-env chart's default command is exactly that bare `tail`, so on the k8s
+# backend tini must be the command itself. tini exists only to reap; `-s`
+# (subreaper) keeps it correct where it is not PID 1 -- the local-docker case.
+#
+# This is a workaround. Reported upstream, so remove this (and the tini
+# install in apn/lean/Dockerfile's base stage) if it is fixed there:
+# https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/issues/251
+SANDBOX_COMMAND = ["/usr/bin/tini", "-s", "--", "tail", "-f", "/dev/null"]
+
 
 def _docker_tag_component(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.-]", "_", value)
@@ -94,7 +109,7 @@ def get_compose_file_content(fc_commit: str, literature: bool = False) -> str:
                 "image": f"{IMAGE_REPOSITORY}:{get_identifier_for_image(agent_kind, fc_commit)}",
                 "build": _build_section(agent_kind, fc_commit),
                 "init": True,
-                "entrypoint": "tail -f /dev/null",
+                "entrypoint": list(SANDBOX_COMMAND),
                 "mem_limit": f"{AGENT_MEMORY_GIB}g",
                 "network_mode": "none",
             },
@@ -102,7 +117,7 @@ def get_compose_file_content(fc_commit: str, literature: bool = False) -> str:
                 "image": f"{IMAGE_REPOSITORY}:{get_identifier_for_image('comparator', fc_commit)}",
                 "build": _build_section("comparator", fc_commit),
                 "init": True,
-                "entrypoint": "tail -f /dev/null",
+                "entrypoint": list(SANDBOX_COMMAND),
                 "mem_limit": f"{COMPARATOR_MEMORY_GIB}g",
                 "network_mode": "none",
             },
@@ -141,12 +156,16 @@ def get_values_file_content(fc_commit: str, literature: bool = False) -> str:
         "services": {
             "default": {
                 "image": f"{repository}:{get_identifier_for_image(agent_kind, fc_commit)}",
+                # Without this the chart defaults to a bare `tail -f /dev/null`
+                # as PID 1, which never reaps orphans (see SANDBOX_COMMAND).
+                "command": list(SANDBOX_COMMAND),
                 "networkIsolated": True,
                 "dnsRecord": True,
                 "resources": resources(AGENT_MEMORY_GIB),
             },
             "comparator": {
                 "image": f"{repository}:{get_identifier_for_image('comparator', fc_commit)}",
+                "command": list(SANDBOX_COMMAND),
                 "runtimeClassName": "CLUSTER_DEFAULT",
                 "networkIsolated": True,
                 "dnsRecord": True,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apn"
-version = "0.1.9"
+version = "0.1.10"
 description = "An Inspect implementation of the AlphaProof Nexus formal proof-search framework"
 license = "MIT AND Apache-2.0"
 license-files = ["LICENSE"]


### PR DESCRIPTION
Ports epoch-research/PortBench#676 to this repo.

On the k8s backend, PID 1 in every sandbox pod is the agent-env chart's default command, `tail -f /dev/null`, which never calls `wait()`. Anything a sandbox exec orphans is reparented to PID 1 and stays there as a zombie holding its process slot for the life of the pod; once enough accumulate, `fork()` returns EAGAIN and every later command in the sample fails, permanently. PortBench measured this killing ~6% of samples across three eval sets, and diagnosed/verified the fix on a live pod (see the PR above and [the upstream issue](https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/issues/251)).

Local Docker never shows it because the compose `init: true` is honoured there (docker-init reaps). Kubernetes has no init equivalent, so the fix has to be the pod command itself.

The port differs from PortBench in shape because this repo writes the k8s config natively in chart vocabulary instead of letting hawk convert the compose file:

- Both backend writers now take their main command from a shared `SANDBOX_COMMAND` constant (`/usr/bin/tini -s -- tail -f /dev/null`), keeping the two artifacts from drifting. `-s` makes tini a subreaper wherever something else is already PID 1 (the local-docker case), so the one command is correct on both backends.
- tini lands in the Dockerfile's **base** stage, not a service stage: all four service images (`agent`, `agent_corpus`, `comparator`, `generate`) build FROM base and the command is shared by both services, so an image lacking tini would fail to start at all. It is folded into base's existing apt line.
- The code comment records this as a workaround and links the upstream issue, so it can be deleted if [inspect_k8s_sandbox#251](https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox/issues/251) is fixed.

Relevant note: this invalidates the base layer, so every image rebuilds from scratch. ECR tags are immutable and keyed on `apn.__version__`, so the PR includes a bump to 0.1.11rc9 (main is at 0.1.11rc8; the PR's original 0.1.10 was taken by #48 in the meantime) — without it the cluster would keep running the pre-tini images.

