### PR TITLE
Share one Mathlib packages layer between the agent and comparator images

### DIFF
--- a/apn/__init__.py
+++ b/apn/__init__.py
@@ -1,4 +1,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.11rc6"
+__version__ = "0.1.11rc7"

--- a/apn/__init__.py
+++ b/apn/__init__.py
@@ -1,4 +1,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.11rc7"
+__version__ = "0.1.11rc8"

--- a/apn/lean/Dockerfile
+++ b/apn/lean/Dockerfile
@@ -232,11 +232,6 @@ RUN mkdir /staged \
     && cp FormalConjecturesForMathlib.lean /staged/ \
     && cp -r FormalConjecturesForMathlib /staged/FormalConjecturesForMathlib
 
-# base copies .lake in two pieces (build/ into the project, packages/ to
-# /opt/pristine -- see base). Make sure those are the only two things lake left
-# in .lake, so a future lake that adds a third cannot slip past the two COPYs.
-RUN test "$(ls -A .lake | sort | tr '\n' ' ')" = "build packages "
-
 # NOTE: the `Submission` lean_lib registered above is what lets a submission
 # span several modules: the agent's `Submission/Spec.lean` (the entry module,
 # `Submission.Spec`) may `import Submission.…` helper modules the agent writes

--- a/apn/lean/Dockerfile
+++ b/apn/lean/Dockerfile
@@ -224,6 +224,11 @@ RUN mkdir /staged \
     && cp FormalConjecturesForMathlib.lean /staged/ \
     && cp -r FormalConjecturesForMathlib /staged/FormalConjecturesForMathlib
 
+# base copies .lake in two pieces (build/ into the project, packages/ to
+# /opt/pristine -- see base). Make sure those are the only two things lake left
+# in .lake, so a future lake that adds a third cannot slip past the two COPYs.
+RUN test "$(ls -A .lake | sort | tr '\n' ' ')" = "build packages "
+
 # NOTE: `Submission/` is deliberately NOT registered as a lean_lib. The agent's
 # proof is a single file, `Submission/Spec.lean`; the comparator checker copies
 # exactly that file to `run/Solution.lean` and scores it. An
@@ -264,12 +269,26 @@ RUN echo 'export PATH=/root/.elan/bin:$PATH' > /etc/profile.d/elan.sh
 
 WORKDIR /workspace/leanproject
 
-# Lake project metadata + all build artifacts: the FC library oleans and the full
-# Mathlib/dependency set under .lake/packages. Imports resolve from these oleans.
+# Lake project metadata + the FC library's own build artifacts (.lake/build).
+# Imports resolve from these oleans and from the dependency tree below.
 COPY --from=builder /workspace/leanproject/lakefile.toml \
                     /workspace/leanproject/lean-toolchain \
                     /workspace/leanproject/lake-manifest.json ./
-COPY --from=builder /workspace/leanproject/.lake ./.lake
+COPY --from=builder /workspace/leanproject/.lake/build ./.lake/build
+
+# The dependency tree (Mathlib and friends: ~7 GB of oleans) lives OUTSIDE the
+# project, at /opt/pristine/packages, reached through a symlink at the path
+# lake expects. Lake only needs .lake/packages/<pkg> to resolve to a git
+# checkout at the manifest's rev, which a symlink satisfies -- the comparator
+# has run exactly this layout since its per-check reset existed
+# (reset-dotlake.sh relinks .lake/packages to this very location). Laying it
+# out this way from the start makes the tree ONE layer shared by every image
+# built from base: the comparator stage used to `mv` it out of .lake, and a
+# rename across image layers is a copy, which gave that image a second 7 GB
+# layer on top of the one it inherits from here. The agent sees the same
+# layout, so lake resolves packages identically in both images.
+COPY --from=builder /workspace/leanproject/.lake/packages /opt/pristine/packages
+RUN ln -s /opt/pristine/packages .lake/packages
 
 # Note: neither the `Submission/` nor the `run/` directory is copied in. They
 # carry no baked content -- the Python scaffold creates the agent's
@@ -528,14 +547,17 @@ COPY --from=walnut     /opt/walnut  /opt/walnut
 COPY --from=unpackaged /            /usr/local/
 
 # Loogle: the dependency-free binary, its README, and the Mathlib search index
-# it baked next to Mathlib.olean (COPY preserves mtimes, and this stage shares
-# base's layers with loogle, so the index stays valid; were it ever judged
-# stale, loogle transparently rebuilds it).
+# it baked next to Mathlib.olean -- physically under /opt/pristine/packages,
+# where base keeps the dependency tree (.lake/packages is a symlink to it), so
+# the COPY names that real path on both sides rather than leaning on symlink
+# resolution inside COPY. COPY preserves mtimes, and this stage shares base's
+# layers with loogle, so the index stays valid; were it ever judged stale,
+# loogle transparently rebuilds it.
 COPY --from=loogle /opt/loogle/.lake/build/bin/loogle /usr/local/bin/loogle
 COPY --from=loogle /opt/loogle/README.md /usr/local/share/doc/loogle/README.md
 COPY --from=loogle \
-     /workspace/leanproject/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.loogle-index \
-     /workspace/leanproject/.lake/packages/mathlib/.lake/build/lib/lean/Mathlib.loogle-index
+     /opt/pristine/packages/mathlib/.lake/build/lib/lean/Mathlib.loogle-index \
+     /opt/pristine/packages/mathlib/.lake/build/lib/lean/Mathlib.loogle-index
 
 # Exposure (header rule 4): agent-commands lists every command the agent gets
 # from the envs, one absolute path per line, linked into /usr/local/bin. That
@@ -728,23 +750,25 @@ COPY reset-dotlake.sh /opt/apn/reset-dotlake.sh
 RUN chmod 755 /opt/apn/reset-dotlake.sh
 
 # Stage the pristine workspace tree the reset script restores from:
-#   /opt/pristine/dot-lake  -- the project .lake minus packages/ (lake config
-#                              cache + the FC build artifacts, tens of MB;
-#                              copied into .lake on every reset). The builder's
-#                              Challenge/Solution stub artifacts ride along:
-#                              staged files hash differently, so lake rebuilds
-#                              them (and reuse on a byte-identical file is the
-#                              same compilation).
-#   /opt/pristine/packages  -- the heavy Mathlib/dependency artifacts; stay
-#                              root-owned outside .lake (and so outside the
-#                              landrun write grant) and are symlinked into the
-#                              fresh .lake (never copied, never writable).
+#   /opt/pristine/dot-lake  -- the project .lake minus the packages link (lake
+#                              config cache + the FC build artifacts, tens of
+#                              MB; copied into .lake on every reset). The
+#                              builder's Challenge/Solution stub artifacts ride
+#                              along: staged files hash differently, so lake
+#                              rebuilds them (and reuse on a byte-identical file
+#                              is the same compilation).
+#   /opt/pristine/packages  -- the heavy Mathlib/dependency artifacts, at this
+#                              path since base; stay root-owned outside .lake
+#                              (and so outside the landrun write grant) and are
+#                              symlinked into the fresh .lake (never copied,
+#                              never writable).
 # Neither .lake nor run/ is recreated here: the reset script rebuilds .lake
 # and the checker rebuilds run/ before every check, so the image need not
-# carry either.
+# carry either. The mv is a copy (a rename across image layers cannot be a
+# rename), but only of the small skeleton: the packages never move.
 RUN mkdir -p /opt/pristine \
-    && mv /workspace/leanproject/.lake/packages /opt/pristine/packages \
-    && mv /workspace/leanproject/.lake /opt/pristine/dot-lake
+    && mv /workspace/leanproject/.lake /opt/pristine/dot-lake \
+    && rm /opt/pristine/dot-lake/packages
 
 # The non-privileged runtime user (comparator README assumption 6). It owns
 # exactly the project dir, in which the reset script recreates .lake and the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apn"
-version = "0.1.11rc6"
+version = "0.1.11rc7"
 description = "An Inspect implementation of the AlphaProof Nexus formal proof-search framework"
 license = "MIT AND Apache-2.0"
 license-files = ["LICENSE"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "apn"
-version = "0.1.11rc7"
+version = "0.1.11rc8"
 description = "An Inspect implementation of the AlphaProof Nexus formal proof-search framework"
 license = "MIT AND Apache-2.0"
 license-files = ["LICENSE"]

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "apn"
-version = "0.1.11rc6"
+version = "0.1.11rc7"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -182,7 +182,7 @@ wheels = [
 
 [[package]]
 name = "apn"
-version = "0.1.11rc7"
+version = "0.1.11rc8"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
The `comparator` image carried Mathlib twice. `base` copies the whole `.lake` tree (7.09 GB, almost all of it `.lake/packages`) into its own layer, and the comparator stage then ran `mv .lake/packages /opt/pristine/packages`. A rename across image layers is not a rename: overlayfs returns EXDEV, `mv` falls back to copy-and-delete, and the result is a second 7.09 GB layer while the inherited one is merely whited out and still downloaded on every pull. Measured on a HEAD build (`docker history`): the comparator was 17.6 GB on disk with two 7.09 GB layers; it is now 10.6 GB with one.

The fix is to lay the tree out the way the comparator already runs it. `reset-dotlake.sh` relinks `.lake/packages -> /opt/pristine/packages` before every check, so `base` now copies the builder's `.lake/packages` straight to `/opt/pristine/packages`, copies `.lake/build` (the FC library's own artifacts, 92 MB) into the project, and symlinks `.lake/packages` to the pristine tree. Lake only needs `.lake/packages/<pkg>` to resolve to a git checkout at the manifest's rev, which the symlink satisfies. The comparator stage then only moves the 92 MB skeleton and drops the link (the reset recreates it). The agent gets the identical layout, so both images share the one 7 GB layer: ECR stores it once per pin instead of twice, and a node that pulls both images pulls it once.

Changes:
- **Dockerfile, `base`**: `COPY .lake/build` + `COPY .lake/packages -> /opt/pristine/packages` + `ln -s`, replacing the single `COPY .lake`.
- **Dockerfile, `comparator`**: the staging step moves only `.lake` (now the skeleton) to `/opt/pristine/dot-lake` and removes the packages link; the packages `mv` is gone. `reset-dotlake.sh` is unchanged.
- **Dockerfile, `agent`**: the Loogle index COPY names the real path under `/opt/pristine/packages` on both sides instead of relying on symlink resolution inside COPY.
- **Version**: `scripts/bump_version.py rc` to 0.1.11rc8, so CI builds and pushes the new layout (tags are immutable and keyed on `apn.__version__` + FC pin; main already took rc7 in #52, whose images have the old layout).

Verified on local builds of both targets for pin 67338a15: `docker history` shows the packages layer once per image and `docker inspect` shows 11 layers shared between them; in the agent, `lake build --no-build` reports all 7999 jobs up to date through the symlink, a compile via `lake env lean` works, and `lake env loogle --module Mathlib` finds its baked index; in the comparator, a reset followed by a Challenge/Solution build, `lean4export` and the kernel replay accepts a valid proof and rejects a `sorry` with `Illegal axiom detected: 'sorryAx'`. `tests/test_singlefile_proof.py` and `tests/test_comparator_security.py` passed against those images before main was merged in. The merge with #52 (multi-file `Submission` lib, staging changes) conflicted only in comments; the layout change is orthogonal to where the packages live, and the comparator-tests CI suites build the merged Dockerfile.
